### PR TITLE
docs(crawler): add docstrings to domain, usecase, and main modules

### DIFF
--- a/workflows/crawler/domain/paper.py
+++ b/workflows/crawler/domain/paper.py
@@ -2,7 +2,22 @@ from pydantic import BaseModel
 
 
 class Paper(BaseModel):
-    """論文を表す"""
+    """学術論文のメタデータを表すドメインモデル。
+
+    DBLPなどの学術データベースから取得した論文情報を格納します。
+    タイトル、著者、出版年、会場（カンファレンス/ジャーナル）は必須フィールドで、
+    DOIやURLなどの詳細情報はオプションです。
+
+    Attributes:
+        title: 論文のタイトル
+        authors: 著者名のリスト
+        year: 出版年
+        venue: 掲載会場（カンファレンス名やジャーナル名）
+        doi: Digital Object Identifier（オプション）
+        type: 論文の種類（例: "Conference and Workshop Papers"）（オプション）
+        ee: 電子版へのリンク（オプション）
+        url: DBLP上の論文ページURL（オプション）
+    """
 
     title: str
     authors: list[str]

--- a/workflows/crawler/main.py
+++ b/workflows/crawler/main.py
@@ -1,3 +1,9 @@
+"""DBLPクローラーのメインエントリーポイント。
+
+このモジュールは、DBLP APIを使用して学術論文情報を収集するクローラーの
+実行エントリーポイントを提供します。
+"""
+
 import asyncio
 
 from loguru import logger
@@ -6,13 +12,24 @@ from usecase.dblp import DBLPSearch
 
 
 async def recsys_crawl(headers: dict[str, str]) -> None:
-    """RecSysカンファレンスのpaperのタイトルを収集する"""
+    """RecSysカンファレンスの論文情報を収集します。
+
+    2025年のRecSysカンファレンスで発表された論文のメタデータを
+    DBLPから取得し、取得件数をログに出力します。
+
+    Args:
+        headers: HTTPリクエストで使用するヘッダー辞書
+    """
     async with DBLPSearch(headers) as dblp_search_usecase:
         papers = await dblp_search_usecase.fetch_papers(conf="recsys", year=2025, h=1000)
         logger.info(f"Fetched {len(papers)} papers")
 
 
 async def main() -> None:
+    """クローラーの非同期エントリーポイント。
+
+    ログメッセージを出力後、RecSysのクロール処理を実行します。
+    """
     logger.info("Hello from crawler!")
     await recsys_crawl(headers={"User-Agent": "ArchilogBot/1.0"})
 


### PR DESCRIPTION
- Paperドメインモデルに属性定義を含む詳細なdocstringを追加
- main.pyにモジュール概要および各実行関数の説明を追加
- DBLPSearchユースケースにクラス概要、使用例、および各メソッドの引数・戻り値・例外の説明を追加
- コードの可読性と保守性向上のため、パッケージ全体にわたりドキュメントを整備
