### PR TITLE
feat: add retry logic with exponential backoff for HTTP requests

### DIFF
--- a/workflows/crawler/libs/http_utils.py
+++ b/workflows/crawler/libs/http_utils.py
@@ -1,0 +1,74 @@
+from typing import Any, NoReturn
+
+import httpx
+from loguru import logger
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_random_exponential,
+    retry_if_result,
+    RetryCallState,
+)
+
+
+def is_rate_limit(resp: httpx.Response) -> bool:
+    """レスポンスがRate Limitエラー(429)かどうか判定します。"""
+    return resp.status_code == 429
+
+
+def log_and_raise_final_error(retry_state: RetryCallState) -> NoReturn:
+    """リトライ回数超過時のエラーハンドリングを行います。"""
+    attempt = retry_state.attempt_number
+    if retry_state.outcome is None:
+        raise ValueError("Retry state has no outcome")
+    last_response: httpx.Response = retry_state.outcome.result()
+
+    logger.error(
+        f"Rate limit exceeded after {attempt} attempts: {last_response}, url: {last_response.url}"
+    )
+
+    last_response.raise_for_status()
+    # NoReturn型を満たすための到達不能コード(通常は上記で例外が発生する)
+    raise RuntimeError(f"Retry exhausted but response status was {last_response.status_code}")
+
+
+def before_log(retry_state: RetryCallState) -> None:
+    """リトライ前のロギングを行います。"""
+    attempt = retry_state.attempt_number
+
+    if attempt == 1:
+        # retry_stateから安全にURLを取得
+        if retry_state.kwargs and "url" in retry_state.kwargs:
+            url = retry_state.kwargs["url"]
+        elif len(retry_state.args) > 1:
+            url = retry_state.args[1]
+        else:
+            url = "unknown"
+        logger.info(f"Starting request to URL: {url}")
+    else:
+        if retry_state.outcome is None:
+            raise ValueError("Retry state has no outcome")
+        last_response = retry_state.outcome.result()
+        logger.info(
+            f"Attempt {attempt - 1} failed with status {last_response.status_code}, retrying..."
+        )
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=0.5, min=1, max=10),
+    retry=retry_if_result(is_rate_limit),
+    before=before_log,
+    retry_error_callback=log_and_raise_final_error,
+)
+async def post_with_retry(
+    client: httpx.AsyncClient, url: str, params: dict[str, Any], json: dict[str, Any]
+) -> httpx.Response:
+    """指数バックオフとRate Limitリトライ付きでPOSTリクエストを送信します。"""
+    response = await client.post(url, params=params, json=json)
+    # 200 OK: 成功、429: Rate limit（リトライ対象）
+    # それ以外のステータスコードは即座にエラーとして扱う
+    if response.status_code not in (200, 429):
+        response.raise_for_status()
+
+    return response

--- a/workflows/crawler/pyproject.toml
+++ b/workflows/crawler/pyproject.toml
@@ -11,9 +11,11 @@ dependencies = [
   "certifi~=2025.11.12",
   "truststore~=0.10.4",
   "pydantic~=2.12.5",
+  "tenacity~=9.1.2",
 ]
 
 [dependency-groups]
+dev = []
 test = [
   "pytest~=9.0.1",
   "pytest-asyncio>=1.3.0",

--- a/workflows/crawler/tests/test_semantic_scholar.py
+++ b/workflows/crawler/tests/test_semantic_scholar.py
@@ -75,7 +75,6 @@ async def test_enrich_papers_success(
     mock_api_response.json.return_value = mock_semantic_scholar_response
 
     mocker.patch("httpx.AsyncClient.post", return_value=mock_api_response)
-    mocker.patch("httpx.AsyncClient.aclose")
 
     async with SemanticScholarSearch(headers) as search:
         enriched_papers = await search.enrich_papers(sample_papers)
@@ -107,7 +106,6 @@ async def test_enrich_papers_with_partial_data(
     mock_api_response.json.return_value = partial_response
 
     mocker.patch("httpx.AsyncClient.post", return_value=mock_api_response)
-    mocker.patch("httpx.AsyncClient.aclose")
 
     async with SemanticScholarSearch(headers) as search:
         enriched_papers = await search.enrich_papers(sample_papers)
@@ -268,7 +266,6 @@ async def test_enrich_papers_api_error(
     mock_response.raise_for_status = mock_raise_for_status
 
     mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
-    mocker.patch("httpx.AsyncClient.aclose")
 
     async with SemanticScholarSearch(headers) as search:
         with pytest.raises(Exception):  # httpx.HTTPStatusError

--- a/workflows/crawler/usecase/semantic_scholar.py
+++ b/workflows/crawler/usecase/semantic_scholar.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 from loguru import logger
+from libs.http_utils import post_with_retry
 
 from domain.paper import Paper
 
@@ -169,7 +170,9 @@ class SemanticScholarSearch:
         params = {"fields": "externalIds,abstract,openAccessPdf"}
         payload = {"ids": [f"DOI:{doi}" for doi in dois]}
 
-        resp = await self.client.post(self.paper_batch_search_api, params=params, json=payload)
+        resp = await post_with_retry(
+            self.client, self.paper_batch_search_api, params=params, json=payload
+        )
         resp.raise_for_status()
 
         data: list[dict[str, Any] | None] = resp.json()

--- a/workflows/crawler/uv.lock
+++ b/workflows/crawler/uv.lock
@@ -51,6 +51,7 @@ dependencies = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "pydantic" },
+    { name = "tenacity" },
     { name = "truststore" },
 ]
 
@@ -73,10 +74,12 @@ requires-dist = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "loguru", specifier = "~=0.7.3" },
     { name = "pydantic", specifier = "~=2.12.5" },
+    { name = "tenacity", specifier = "~=9.1.2" },
     { name = "truststore", specifier = "~=0.10.4" },
 ]
 
 [package.metadata.requires-dev]
+dev = []
 lint = [
     { name = "mypy", specifier = "~=1.19.0" },
     { name = "ruff", specifier = "~=0.14.7" },
@@ -432,6 +435,15 @@ name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
 
 [[package]]
 name = "truststore"


### PR DESCRIPTION
- Add a new utility `post_with_retry` in `libs/http_utils.py` using the tenacity library to handle 429 Rate Limit errors.
- Integrate the retry mechanism into `SemanticScholarSearch` for more resilient batch paper lookups.
- Add `tenacity` as a dependency in `pyproject.toml` and update `uv.lock`.
- Clean up redundant `httpx.AsyncClient.aclose` mocks in `test_semantic_scholar.py`.
