### PR TITLE
feat(infra): setup tfstate management for dev environment

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -21,16 +21,29 @@ infra/terraform/
 ├── environments/
 │   ├── .gitignore
 │   └── dev/
-│       └── crawler/
-│           ├── Makefile
+│       ├── crawler/
+│       │   ├── Makefile
+│       │   ├── backend.tf
+│       │   ├── main.tf
+│       │   ├── outputs.tf
+│       │   ├── providers.tf
+│       │   ├── terraform.tfstate
+│       │   ├── terraform.tfvars
+│       │   └── variables.tf
+│       └── tfstate/
 │           ├── backend.tf
 │           ├── main.tf
 │           ├── outputs.tf
 │           ├── providers.tf
-│           ├── terraform.tfstate
-│           ├── terraform.tfvars
-│           └── variables.tf
+│           ├── variables.tf
+│           └── terraform.tfvars
 ├── modules/
+│   ├── datalake/
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── variables.tf
+│   │   └── README.md
 │   ├── google_project_services/
 │   │   ├── main.tf
 │   │   ├── providers.tf
@@ -39,7 +52,8 @@ infra/terraform/
 │       ├── main.tf
 │       ├── outputs.tf
 │       ├── providers.tf
-│       └── variables.tf
+│       ├── variables.tf
+│       └── README.md
 └── scripts/
     └── common.mk
 ```
@@ -51,10 +65,12 @@ infra/terraform/
 `dev/` 配下に環境別の構成を置き、さらにサービス単位で分割しています。
 
 - `dev/crawler/`: 開発環境の crawler 用 root module
+- `dev/tfstate/`: Terraform state 管理用インフラを構築する root module
 
 ### `modules/`
 複数の環境で再利用する module を配置します。
 
+- `datalake/`: GCP のデータレイク用 GCS バケットを作成する module
 - `google_project_services/`: GCP の API 有効化を行う module
 - `tfstate_gcs_bucket/`: Terraform の state 管理用 GCS バケットを作成する module
 
@@ -68,3 +84,24 @@ Makefile からインクルードされる共通ターゲットなどを配置�
 - root module は `environments/<env>/<service>` に配置し、環境ごとの入力値は `terraform.tfvars` で管理します。
 - module の追加・更新は `modules/` 配下に集約し、root module 側で呼び出します。
 - `terraform.tfstate` は環境ごとの状態を保持します。リモート backend を使う場合は `backend.tf` で設定します。
+
+## for_each を使う場合の outputs 出力
+
+module やリソースを `for_each` でループさせている場合、複数の属性を list で出力するには以下のように記述します：
+
+```hcl
+# 複数のリソース/モジュールを list で出力する例
+output "bucket_ids" {
+  value       = [for key, bucket in module.tfstate_bucket : bucket.tfstate_gcs_bucket_id]
+  description = "List of all tfstate bucket IDs"
+}
+
+# より詳しい情報を含める場合
+output "buckets" {
+  value = [for key, bucket in module.tfstate_bucket : {
+    project_id = key
+    bucket_id  = bucket.tfstate_gcs_bucket_id
+  }]
+  description = "List of all tfstate buckets with their project IDs"
+}
+```

--- a/infra/terraform/environments/dev/tfstate/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/tfstate/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
+    "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
+    "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
+    "zh:60c96075fc082d9584b9cb8f48f0d23f90fd4344e6141a417580c6bad1b21957",
+    "zh:ad82cece07a0816153e3fc6cb6d7672c6c009742dc802ab434a83d0731d94ae7",
+    "zh:aebbf8a0bd3af0b6c705d5d85ec51891f533b83dcbae7249e64a252efc6fd862",
+    "zh:bfbb19a5b46950eaf0a83cea09a5992d1b0e96792130faeb6c733609dc2913df",
+    "zh:c196b4c82d0252fa751ee3cd84433bc483b7ce7d6fcab5db0413dbaa9f218650",
+    "zh:db1c83777bc6d7fc195be83712a9f503e9a5a1f7326fd6968d9812acc53f2056",
+    "zh:dcd58beeac9d1889e5532cfcd3bd8dec5568ab06b0a81427bc9b35931b6f0178",
+    "zh:eaeedc86c2d01630a3166ae98d5138e9bf9463b2a606d7f7df6d465d1501f28f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
+    "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
+    "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
+    "zh:5064a8ffda6f8c6b5e72842623a6dc433fd8d8e4013f9266e2636e140a674f6a",
+    "zh:5f383784682442c67a145c4c9117864da735b149aa0e6feefb7f5c0eab738e63",
+    "zh:7fb9526dfeae6e9edd61badfd2c6c64e690e332330a88ccc8deb837d8d08cfc7",
+    "zh:84d707e934b4a2d5bf8ff6ef4758328c93ece119e5fcda09686f47db4fb68e84",
+    "zh:9aab258c4a614f2c05468893891ba6af517c448389ad080831f12f4d52048646",
+    "zh:9f8d8d7c11697b36c0f5d4e54882d7448923bb8d5083a1e50ed63043cb60dda6",
+    "zh:ad9a5a714e60f31f2576b246ac6852b3423ed62ee9537cbabf7fd147207f9e77",
+    "zh:c1098525b4a7fa8aa39cef056718c0f176842defb7dc284bc66148377d5d125d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9b705921562316bdf89e2fb310c036d3cc7bb3bf973fef318da0888deea82fa",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/infra/terraform/environments/dev/tfstate/Makefile
+++ b/infra/terraform/environments/dev/tfstate/Makefile
@@ -1,0 +1,18 @@
+.DEFAULT_GOAL := help
+include ../../../scripts/common.mk
+
+.PHONY: init
+init: # initialize terraform
+	terraform init -backend-config=config.gcs.tfbackend
+
+.PHONY: plan
+plan: # plan terraform
+	terraform plan
+
+.PHONY: apply
+apply: # apply terraform
+	terraform apply
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -h -E '^[a-zA-Z0-9 -]+:.*#' $(MAKEFILE_LIST) | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done

--- a/infra/terraform/environments/dev/tfstate/backend.tf
+++ b/infra/terraform/environments/dev/tfstate/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  # partial backend configurationで指定するため、ここでは空を設定
+  # backend "gcs" {}
+  backend "local" {}
+}

--- a/infra/terraform/environments/dev/tfstate/backend.tf
+++ b/infra/terraform/environments/dev/tfstate/backend.tf
@@ -1,5 +1,4 @@
 terraform {
   # partial backend configurationで指定するため、ここでは空を設定
-  # backend "gcs" {}
-  backend "local" {}
+  backend "gcs" {}
 }

--- a/infra/terraform/environments/dev/tfstate/config.gcs.tfbackend
+++ b/infra/terraform/environments/dev/tfstate/config.gcs.tfbackend
@@ -1,1 +1,1 @@
-bucket = "haru256-devgist-tf"
+bucket = "haru256-devgist-tf-tfstate"

--- a/infra/terraform/environments/dev/tfstate/config.gcs.tfbackend
+++ b/infra/terraform/environments/dev/tfstate/config.gcs.tfbackend
@@ -1,0 +1,1 @@
+bucket = "haru256-devgist-tf"

--- a/infra/terraform/environments/dev/tfstate/main.tf
+++ b/infra/terraform/environments/dev/tfstate/main.tf
@@ -18,7 +18,7 @@ data "google_project" "project" {
 module "required_project_services" {
   source = "../../../modules/google_project_services"
 
-  project_id        = var.gcp_project_id
+  project_id        = data.google_project.project
   required_services = local.required_services
   wait_seconds      = 30
 }

--- a/infra/terraform/environments/dev/tfstate/main.tf
+++ b/infra/terraform/environments/dev/tfstate/main.tf
@@ -1,0 +1,34 @@
+locals {
+  # このTerraform構成で必要な全APIをリスト化
+  required_services = [
+    "storage.googleapis.com", # GCSモジュール用
+  ]
+  # tfstateの管理対象プロジェクトIDのリスト
+  tfstate_gcp_project_ids = [
+    "haru256-devgist-tf",
+  ]
+}
+
+# google cloud project
+data "google_project" "project" {
+  project_id = var.gcp_project_id
+}
+
+# 必要なAPIをすべて有効化し待機
+module "required_project_services" {
+  source = "../../../modules/google_project_services"
+
+  project_id        = var.gcp_project_id
+  required_services = local.required_services
+  wait_seconds      = 30
+}
+
+# create the bucket for terraform state
+module "tfstate_bucket" {
+  for_each = toset(local.tfstate_gcp_project_ids)
+
+  source                 = "../../../modules/tfstate_gcs_bucket"
+  bucket_gcp_project_id  = var.gcp_project_id
+  tfstate_gcp_project_id = each.value
+  depends_on             = [module.required_project_services]
+}

--- a/infra/terraform/environments/dev/tfstate/main.tf
+++ b/infra/terraform/environments/dev/tfstate/main.tf
@@ -3,10 +3,6 @@ locals {
   required_services = [
     "storage.googleapis.com", # GCSモジュール用
   ]
-  # tfstateの管理対象プロジェクトIDのリスト
-  tfstate_gcp_project_ids = [
-    "haru256-devgist-tf",
-  ]
 }
 
 # google cloud project
@@ -25,7 +21,7 @@ module "required_project_services" {
 
 # create the bucket for terraform state
 module "tfstate_bucket" {
-  for_each = toset(local.tfstate_gcp_project_ids)
+  for_each = toset(var.tfstate_gcp_project_ids)
 
   source                 = "../../../modules/tfstate_gcs_bucket"
   bucket_gcp_project_id  = var.gcp_project_id

--- a/infra/terraform/environments/dev/tfstate/outputs.tf
+++ b/infra/terraform/environments/dev/tfstate/outputs.tf
@@ -1,0 +1,7 @@
+output "tfstate_buckets" {
+  value = [for key, bucket in module.tfstate_bucket : {
+    project_id = key
+    bucket_id  = bucket.tfstate_gcs_bucket_id
+  }]
+  description = "List of all tfstate buckets with their project IDs"
+}

--- a/infra/terraform/environments/dev/tfstate/providers.tf
+++ b/infra/terraform/environments/dev/tfstate/providers.tf
@@ -1,0 +1,23 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>7.18.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>7.18.0"
+    }
+  }
+}

--- a/infra/terraform/environments/dev/tfstate/variables.tf
+++ b/infra/terraform/environments/dev/tfstate/variables.tf
@@ -1,0 +1,9 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "The ID of GCP project"
+}
+
+variable "gcp_default_region" {
+  type        = string
+  description = "The name of GCP default region"
+}

--- a/infra/terraform/environments/dev/tfstate/variables.tf
+++ b/infra/terraform/environments/dev/tfstate/variables.tf
@@ -7,3 +7,8 @@ variable "gcp_default_region" {
   type        = string
   description = "The name of GCP default region"
 }
+
+variable "tfstate_gcp_project_ids" {
+  type        = list(string)
+  description = "A list of GCP project IDs for which to create tfstate buckets."
+}

--- a/infra/terraform/modules/tfstate_gcs_bucket/README.md
+++ b/infra/terraform/modules/tfstate_gcs_bucket/README.md
@@ -32,8 +32,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_bucket_gcp_project_id"></a> [bucket\_gcp\_project\_id](#input\_bucket\_gcp\_project\_id) | The ID of the GCP project where the GCS bucket for tfstate will be created. | `string` | n/a | yes |
+| <a name="input_tfstate_gcp_project_id"></a> [tfstate\_gcp\_project\_id](#input\_tfstate\_gcp\_project\_id) | The ID of the GCP project to be managed by Terraform. | `string` | n/a | yes |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | The location of the GCS bucket for tfstate. | `string` | `"US"` | no |
-| <a name="input_gcp_project_id"></a> [gcp\_project\_id](#input\_gcp\_project\_id) | The ID for your GCP project | `string` | n/a | yes |
 
 ## Outputs
 
@@ -42,8 +43,82 @@ No modules.
 | <a name="output_tfstate_gcs_bucket_id"></a> [tfstate\_gcs\_bucket\_id](#output\_tfstate\_gcs\_bucket\_id) | The ID of the bucket used to store terraform state |
 <!-- END_TF_DOCS -->
 
-## Notes
+## 機能
+
+- **バージョニング**: 複数世代の state を保持し、ロールバック時に対応可能
+- **ライフサイクル管理**: 古いバージョン（3 世代以上前）は自動削除
+- **Autoclass**: アクセスパターンに基づいて自動的にストレージクラスを最適化
+
+## 使用例
+
+### 単一プロジェクトの場合
+
+```hcl
+module "tfstate_bucket" {
+  source = "../../../modules/tfstate_gcs_bucket"
+
+  bucket_gcp_project_id  = var.gcp_project_id
+  tfstate_gcp_project_id = "my-project-id"
+  bucket_location        = "US"
+}
+
+output "tfstate_bucket_id" {
+  value = module.tfstate_bucket.tfstate_gcs_bucket_id
+}
+```
+
+### 複数プロジェクトを管理する場合（for_each）
+
+```hcl
+locals {
+  tfstate_gcp_project_ids = [
+    "project-a-id",
+    "project-b-id",
+  ]
+}
+
+module "tfstate_bucket" {
+  for_each = toset(local.tfstate_gcp_project_ids)
+
+  source = "../../../modules/tfstate_gcs_bucket"
+
+  bucket_gcp_project_id  = var.gcp_project_id
+  tfstate_gcp_project_id = each.value
+  bucket_location        = "US"
+}
+
+# 複数バケットの ID を list で出力
+output "tfstate_bucket_ids" {
+  value = [for key, bucket in module.tfstate_bucket : bucket.tfstate_gcs_bucket_id]
+}
+
+# より詳しい情報を出力する場合
+output "tfstate_buckets" {
+  value = [for key, bucket in module.tfstate_bucket : {
+    project_id = key
+    bucket_id  = bucket.tfstate_gcs_bucket_id
+  }]
+}
+```
+
+## 注意事項
 
 - Storage API（`storage.googleapis.com`）を有効化してからバケットを作成します。
-- バケット名は `${gcp_project_id}-tfstate` です。
-- バージョニングを有効化し、古いバージョンは一定数を超えると削除します。
+- バケット名は `${tfstate_gcp_project_id}-tfstate` で自動生成されます。
+- バージョニングは有効化され、古いバージョンは一定数を超えると削除されます。
+- `force_destroy = false` で、バケット削除時の誤削除を防止しています。
+- `uniform_bucket_level_access = true` で、バケットレベルのアクセス制御を統一しています。
+
+## バックエンド設定例
+
+作成したバケットを Terraform backend として使う場合：
+
+```hcl
+# backend.tf
+terraform {
+  backend "gcs" {
+    bucket = "my-project-id-tfstate"
+    prefix = "terraform/state"
+  }
+}
+```

--- a/infra/terraform/modules/tfstate_gcs_bucket/main.tf
+++ b/infra/terraform/modules/tfstate_gcs_bucket/main.tf
@@ -1,5 +1,6 @@
 resource "google_storage_bucket" "tfstate_bucket" {
-  name                        = "${var.gcp_project_id}-tfstate"
+  project                     = var.bucket_gcp_project_id
+  name                        = "${var.tfstate_gcp_project_id}-tfstate"
   location                    = var.bucket_location
   force_destroy               = false
   storage_class               = "STANDARD"

--- a/infra/terraform/modules/tfstate_gcs_bucket/variables.tf
+++ b/infra/terraform/modules/tfstate_gcs_bucket/variables.tf
@@ -1,6 +1,11 @@
-variable "gcp_project_id" {
+variable "bucket_gcp_project_id" {
   type        = string
-  description = "The ID for your GCP project"
+  description = "The ID of the GCP project where the GCS bucket for tfstate will be created."
+}
+
+variable "tfstate_gcp_project_id" {
+  type        = string
+  description = "The ID of the GCP project to be managed by Terraform."
 }
 
 variable "bucket_location" {

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-python = "3.14.3"
+python = "3.12.12"
 terraform = "1.14.5"
 terraform-docs = "latest"
 tflint = "0.61.0"


### PR DESCRIPTION
## Summary
- feat(infra): setup tfstate management for dev environment

## Related Issues
#46 

## Changes
- Add initial Terraform configuration for managing remote state GCS buckets in the dev environment
- Refactor the tfstate_gcs_bucket module to support separate IDs for the bucket project and the target project
- Downgrade Python version to 3.12.12 in mise.toml to match project requirements

## How to Test
- nothing

## Additional Context
- nothing
