### PR TITLE
[codex] feat(infra): restructure terraform environments based on new ADRs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,9 @@
 | `INFRA-ADR-001` | `infra` | GCPプロジェクト構成と環境分離戦略 | Accepted | [docs/adr/infra/001-gcp-project-structure.md](infra/001-gcp-project-structure.md) |
 | `INFRA-ADR-002` | `infra` | Terraform構成: ドメイン駆動モジュールとマルチプロジェクト戦略の採用 | Accepted | [docs/adr/infra/002-terraform-module-structure.md](infra/002-terraform-module-structure.md) |
 | `INFRA-ADR-003` | `infra` | Crawler実行基盤として Cloud Run Jobs を採用する | Accepted | [docs/adr/infra/003-crawler-execution-platform.md](infra/003-crawler-execution-platform.md) |
+| `INFRA-ADR-004` | `infra` | Terraform State Project と Ops Project を分離する | Accepted | [docs/adr/infra/004-separate-tf-and-ops-projects.md](infra/004-separate-tf-and-ops-projects.md) |
+| `INFRA-ADR-005` | `infra` | Terraform environments は GCP project ごとに分割する | Accepted | [docs/adr/infra/005-terraform-environment-slicing.md](infra/005-terraform-environment-slicing.md) |
+| `INFRA-ADR-006` | `infra` | Cross-project Terraform output 共有戦略 | Accepted | [docs/adr/infra/006-cross-project-output-sharing.md](infra/006-cross-project-output-sharing.md) |
 | `CRAWLER-ADR-001` | `crawler` | 論文収集クローラーの実装言語としてPythonを採用 | Accepted | [docs/adr/crawler/001-language-selection.md](crawler/001-language-selection.md) |
 | `CRAWLER-ADR-002` | `crawler` | XMLパースにdefusedxmlを採用 | Accepted | [docs/adr/crawler/002-xml-parsing-security.md](crawler/002-xml-parsing-security.md) |
 

--- a/docs/adr/infra/004-separate-tf-and-ops-projects.md
+++ b/docs/adr/infra/004-separate-tf-and-ops-projects.md
@@ -1,0 +1,170 @@
+# INFRA-ADR-004 Terraform State Project と Ops Project を分離する
+
+## Conclusion (結論)
+
+- DevGist の GCP project 構成として、`Terraform State` を保持する project と、`Artifact Registry` や CI/CD 基盤を保持する `Ops Project` を分離する。
+- `haru256-devgist-tf` は Terraform state 専用 project とし、`haru256-devgist-ops` を別途運用基盤 project として設ける。
+- `Artifact Registry`、GitHub Actions 連携、将来の WIF / 共通 CI 用 Service Account は `Ops Project` に配置する。
+
+## Status (ステータス)
+
+Accepted
+
+## Context (背景・課題)
+
+### 背景
+
+既存の ADR では、Terraform state を保持する管理用 project と、Artifact Registry や CI/CD 基盤の置き場が明確に分離されていなかった。
+
+- `INFRA-ADR-001` では `Mgmt Project` として `haru256-devgist-tf` を定義している
+- `INFRA-ADR-002` では `Ops Project` に `Terraform State 保存用バケット` と `Artifact Registry` を同居させている
+
+一方で、Terraform state を保持する project は「最後まで削除してはいけない基盤」であり、コンテナ配布や CI/CD の変更対象となる運用 project と同居させると、役割が混ざる。
+
+### 要件と制約
+
+1. **Terraform state の保護**
+   - tfstate bucket を保持する project は最小限の責務に限定したい
+   - 他の運用基盤変更に巻き込まれて削除・再構成対象になることを避けたい
+
+2. **配布基盤の独立性**
+   - `Artifact Registry` は app/data どちらにも属さない共通基盤として扱いたい
+   - crawler, API, frontend など複数 workload から共有可能にしたい
+
+3. **運用変更の分離**
+   - CI/CD, WIF, 共通 Service Account, イメージ配布まわりは独立に変更できるようにしたい
+   - tfstate project には不要な変更を入れたくない
+
+4. **既存方針との整合**
+   - `App Project` は stateless compute、`Data Project` は stateful data という既存整理は維持したい
+   - crawler は `App Project` 上の `Cloud Run Jobs` とする前提を保ちたい
+
+### 比較した選択肢
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: `tf` と `ops` を分離 | 管理基盤を長期保護しつつ、運用基盤を拡張したい場合 | tfstate の保護がしやすい。Artifact Registry と CI/CD を独立運用しやすい。責務が明確。 | project 数が増える。Terraform root module も増える。 | 採用 |
+| Option B: `tf` と `ops` を統合 | 小規模で project 数を最小化したい場合 | シンプルで初期構築が速い。 | tfstate と配布基盤が同居し、削除や変更の blast radius が広がる。 | 非採用 |
+| Option C: `Artifact Registry` を App Project に置く | app 単位で閉じた配布運用をしたい場合 | app と image store の関係が単純。 | 共有基盤として扱いづらい。将来の workload 追加時に責務が崩れる。 | 非採用 |
+
+### 選定観点
+
+- tfstate project を最も保守的に扱えるか
+- Artifact Registry を共通運用基盤として自然に配置できるか
+- 将来の CI/CD 拡張に耐えられるか
+- 既存の App / Data 分離と矛盾しないか
+
+## Considered Options
+
+### Option A: `tf` と `ops` を分離する [採用]
+
+`haru256-devgist-tf` を Terraform state 専用 project とし、`haru256-devgist-ops` を運用基盤 project として別途設ける。
+
+採用理由:
+
+- **tfstate project の責務を極小化できる**
+  - 最も重要な state 管理基盤を、Artifact Registry や CI/CD の日常的な変更から切り離せる。
+  - 「tfstate がある project は消してはいけない」という運用ルールを徹底しやすい。
+
+- **Ops 基盤の拡張余地が自然**
+  - Artifact Registry, WIF, GitHub Actions 連携、共通 Service Account などを 1 つの運用 project に集約できる。
+  - 将来 app や worker が増えても、共通配布基盤として再利用しやすい。
+
+- **既存 ADR と大きく衝突しない**
+  - `App Project` を stateless compute、`Data Project` を stateful data とする整理は維持できる。
+  - 変更対象は `Mgmt/Ops` の切り分けだけに閉じる。
+
+### Option B: `tf` と `ops` を統合する [却下]
+
+`haru256-devgist-tf` に tfstate bucket と Artifact Registry を同居させる。
+
+却下理由:
+
+- tfstate を保持する project に、日常的に変更される配布基盤を同居させることになる。
+- 「tfstate project は極力不変に保つ」という運用ポリシーを取りにくい。
+- project 名としても `tf` が過度に狭い意味になり、役割の誤解を招きやすい。
+
+### Option C: `Artifact Registry` を App Project に置く [却下]
+
+各 app project 側に image store を置き、Cloud Run から同一 project 内で参照する。
+
+却下理由:
+
+- Artifact Registry が app 専用基盤になり、複数 workload 間の共通配布基盤として扱いづらい。
+- crawler, API, frontend などが増えたときに、どの app project が image store の責任を持つか曖昧になる。
+- app project の責務が「compute」から「配布基盤」まで広がりすぎる。
+
+## Decision (決定事項)
+
+DevGist の GCP project 構成として、`Terraform State Project` と `Ops Project` を分離する。
+
+### 採用方針
+
+- `haru256-devgist-tf`
+  - Terraform state bucket 専用 project とする
+  - 原則として、tfstate 管理以外の常設リソースは置かない
+
+- `haru256-devgist-ops`
+  - Artifact Registry を配置する
+  - GitHub Actions 連携、WIF、共通 CI/CD 用 Service Account などの運用基盤を配置する
+
+- `haru256-devgist-data-{env}`
+  - GCS datalake, Cloud SQL, BigQuery などの stateful data を配置する
+
+- `haru256-devgist-app-{env}`
+  - Cloud Run Jobs, API, frontend などの stateless compute を配置する
+
+### 初期構成
+
+- `tf` project は remote state 管理専用
+- `ops` project に crawler 用を含む Artifact Registry repository を配置
+- crawler は `app-dev` などの App Project 上の `Cloud Run Jobs` として実行
+- crawler の保存先 datalake は `data-dev` などの Data Project に配置
+
+### Supersedes / Clarifications
+
+- `INFRA-ADR-001` の `Mgmt Project` は、以後 `Terraform State Project` として解釈する
+- `INFRA-ADR-002` の `Ops Project` に `Terraform State 保存用バケット` を同居させる記述は、本 ADR で supersede する
+
+### 再検討条件
+
+- 組織的に project 数をさらに削減する必要が出た場合
+- Artifact Registry や CI/CD を別組織・別 billing 単位で管理する必要が出た場合
+- Terraform state の管理方式自体を GCS bucket 以外へ移行する場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- tfstate project を保守的に運用しやすい
+- Ops 基盤の変更が tfstate 管理へ波及しにくい
+- Artifact Registry の責務が明確になり、複数 workload で共有しやすい
+- App / Data / Ops / Tf の境界が明文化される
+
+### Negative (デメリット)
+
+- project 数が増え、初期セットアップがやや重くなる
+- Terraform root module、IAM、CI/CD 設定の記述量が増える
+- cross-project 参照の設計を意識する必要がある
+
+### Risks / Future Review (将来の課題)
+
+- `ops` project への共通基盤集約が進みすぎると、今度は `ops` の責務が肥大化する可能性がある
+- IAM 設計を雑にすると、分離した project 境界が形骸化する
+- CI/CD 導入時に、`ops` project と `app/data` project の権限境界を明示的に設計する必要がある
+
+## Next Steps
+
+1. `infra/README.md` に current project responsibilities を明記する
+2. Terraform root module を `tf`, `ops`, `data`, `app` の責務に沿って整理する
+3. Artifact Registry は `ops` project から apply する構成へ移す
+4. crawler の deploy/runtime 設計で、`ops` の image store を `app` project から参照する
+5. GitHub Actions / WIF / Service Account の責務分担を別ドキュメントまたは次の ADR で明確化する
+
+## Related Documents
+
+- [INFRA-ADR-001] GCPプロジェクト構成と環境分離戦略
+- [INFRA-ADR-002] Terraform構成: ドメイン駆動モジュールとマルチプロジェクト戦略の採用
+- [INFRA-ADR-003] Crawler実行基盤として Cloud Run Jobs を採用する
+- [ADR運用ガイド](../../../docs/adr/README.md)
+- [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/005-terraform-environment-slicing.md
+++ b/docs/adr/infra/005-terraform-environment-slicing.md
@@ -1,0 +1,178 @@
+# INFRA-ADR-005 Terraform environments は GCP project ごとに分割する
+
+## Conclusion (結論)
+
+- Terraform の `environments/` 配下の root module は、基本的に `GCP project` ごとに分割する。
+- `service` ごとに跨る workload は 1 つの root module に閉じ込めず、各 project 側の責務に分解して管理する。
+- service 全体の見通しや apply 順序は、README や Makefile などの運用導線で補う。
+
+## Status (ステータス)
+
+Accepted
+
+## Context (背景・課題)
+
+### 背景
+
+DevGist では `crawler` のように、1 つの service が複数の GCP project に跨る構成を採る。
+
+- image store は `Ops Project`
+- 実行基盤は `App Project`
+- datalake は `Data Project`
+
+この状態で Terraform の `environments/` を `service` ごとに切るか、`project` ごとに切るかを決める必要がある。
+
+### 要件と制約
+
+1. **state 境界の明確化**
+   - どこまでが 1 つの Terraform state なのかを明確にしたい
+   - blast radius を project 境界に揃えたい
+
+2. **責務の一貫性**
+   - API 有効化、IAM、backend 設定、リソース所有者を project ごとに閉じたい
+   - 共通基盤を service ごとの root module が横取りしないようにしたい
+
+3. **service の見通し**
+   - project ごとに分けると、1 つの service の全体像が追いづらくなる
+   - 依存関係や apply 順序が人間に分かる必要がある
+
+4. **運用性**
+   - apply 対象と順序が曖昧にならないこと
+   - 将来、service や project が増えても拡張しやすいこと
+
+### 比較した選択肢
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: project ごとに分割 | project が state 境界と一致する場合 | state と責務が一致する。blast radius が明確。IAM/API/backend を project 単位で閉じられる。 | service 全体の見通しは別途補助が必要。 | 採用 |
+| Option B: service ごとに分割 | 1 service がほぼ 1 project に閉じる場合 | service の全体像が 1 箇所で見やすい。 | 複数 project に跨る service で責務が混ざる。共通基盤を service が抱え込みやすい。 | 非採用 |
+| Option C: project と service の二重 root module | 両方の見通しを root module で直接持ちたい場合 | 見た目上は分かりやすい。 | state の責務が重複しやすい。所有境界が曖昧。運用負荷が高い。 | 非採用 |
+
+### 選定観点
+
+- Terraform state の責務境界が自然か
+- 複数 project に跨る service を無理なく表現できるか
+- apply 対象と blast radius が読みやすいか
+- service の見通しを別レイヤで補えるか
+
+## Considered Options
+
+### Option A: `environments/` を project ごとに切る [採用]
+
+`devgist-tf`, `devgist-ops`, `devgist-data/dev`, `devgist-app/dev` のように、GCP project ごとに root module を配置する。
+
+採用理由:
+
+- **state 境界が明確**
+  - Terraform state を project の責務に一致させやすい。
+  - どの apply がどの project に影響するかが読みやすい。
+
+- **複数 project に跨る service と相性がよい**
+  - crawler のような workload を、`ops/app/data` の各責務に分解して自然に配置できる。
+  - `Artifact Registry`、`Cloud Run Jobs`、`GCS` を別 state で管理できる。
+
+- **基盤責務を service 側に漏らさない**
+  - API enablement、backend、IAM、共通基盤の ownership を project 側に保てる。
+  - service ごとの root module が共通基盤を抱え込む設計を避けられる。
+
+### Option B: `environments/` を service ごとに切る [却下]
+
+`crawler`, `api`, `frontend` のように workload 名で root module を切る。
+
+却下理由:
+
+- 1 service が複数 project に跨ると、1 root module に複数責務が混ざる。
+- `ops` の Artifact Registry や `data` の GCS まで service 側 state に入れたくなり、境界が崩れる。
+- 一部だけ更新したいときでも service 全体の state を触ることになりやすい。
+
+### Option C: project と service の両方で root module を持つ [却下]
+
+project ごとの root module と service ごとの root module を並立させる。
+
+却下理由:
+
+- 同じ責務を複数の root module が参照・管理し始める危険がある。
+- source of truth が曖昧になり、どこから apply すべきか分かりにくい。
+- 初期フェーズとしては運用コストが高すぎる。
+
+## Decision (決定事項)
+
+Terraform の `environments/` 配下は、`GCP project` ごとに root module を切る。
+
+### 採用方針
+
+- root module は project 単位で持つ
+  - 例: `devgist-tf`, `devgist-ops`, `devgist-data/dev`, `devgist-app/dev`
+
+- service は root module の単位にはしない
+  - 1 つの service が複数 project に跨る場合は、各 project 側に責務を分解して配置する
+
+- service の全体像は別レイヤで補う
+  - `infra/README.md` に service-to-project 対応表を置く
+  - `workflows/crawler/README.md` のような service README に依存先を書く
+  - Makefile や運用コマンドで apply 順序を定義する
+
+### 初期構成
+
+- `devgist-tf`
+  - Terraform state bucket 管理
+
+- `devgist-ops`
+  - Artifact Registry など共通運用基盤
+
+- `devgist-data/dev`
+  - datalake など stateful data
+
+- `devgist-app/dev`
+  - Cloud Run Jobs / API など stateless compute
+
+- `crawler`
+  - 単独 environment ではなく、`ops`, `app`, `data` に分散配置される workload として扱う
+
+### Clarifications
+
+- `project ごとに切る` のは state 境界のためであり、service の見通しまで project 単位に限定する意図ではない
+- service 全体の設計説明と apply 導線は、README や task runner で補助する
+
+### 再検討条件
+
+- 将来、1 service がほぼ単一 project に閉じ、独立 state のメリットが大きくなった場合
+- project 境界よりも service 境界で apply した方が明らかに運用コストが低いと判明した場合
+- Terraform 以外の deployment tooling で service 単位 orchestration を十分に吸収できる場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- Terraform state と GCP project の責務が揃う
+- apply 対象と blast radius が読みやすい
+- 共有基盤を service ごとの state に混ぜずに済む
+- project を増やしても root module のルールが崩れにくい
+
+### Negative (デメリット)
+
+- service 単位の全体像は root module だけでは見えにくい
+- 1 つの service を有効化するために複数 project を順に apply する必要がある
+- README や Makefile など、補助的な運用ドキュメントが必要になる
+
+### Risks / Future Review (将来の課題)
+
+- README や運用導線を整備しないと「どこに設定があるか分からない」問題が残る
+- apply 順序が暗黙のままだと、project ごとの分割が逆に分かりにくさを生む
+- service README と infra README の内容が乖離しないように維持が必要
+
+## Next Steps
+
+1. `infra/terraform/environments/` の root module を project 単位へ揃える
+2. 旧 `crawler` environment の役割を `ops/app/data` 側へ段階的に移す
+3. `infra/README.md` に service-to-project 対応表と apply 順序を追加する
+4. `workflows/crawler/README.md` に crawler が依存する project と基盤を明記する
+5. 必要なら Makefile で service 単位の apply 導線を提供する
+
+## Related Documents
+
+- [INFRA-ADR-001] GCPプロジェクト構成と環境分離戦略
+- [INFRA-ADR-002] Terraform構成: ドメイン駆動モジュールとマルチプロジェクト戦略の採用
+- [INFRA-ADR-004] Terraform State Project と Ops Project を分離する
+- [ADR運用ガイド](../../../docs/adr/README.md)
+- [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/006-cross-project-output-sharing.md
+++ b/docs/adr/infra/006-cross-project-output-sharing.md
@@ -1,0 +1,252 @@
+# INFRA-ADR-006 Cross-project Terraform output 共有戦略
+
+## Conclusion (結論)
+
+- cross-project で共有する非 secret な値は、原則として `terraform_remote_state` で upstream project の `outputs` を参照する。
+- `terraform_remote_state` の利用対象は非 secret 値に限定し、secret は Terraform outputs 経由で共有しない。
+- secret は `GCP Secret Manager` で管理し、app project 側のアプリケーションランタイムが `Secret Manager` を参照して取得する。
+
+## Status (ステータス)
+
+Accepted
+
+## Context (背景・課題)
+
+### 背景
+
+`INFRA-ADR-004` と `INFRA-ADR-005` により、DevGist の Terraform root module は `GCP project` ごとに分割し、service は `ops/app/data` に責務分解して扱う方針になった。
+
+この構成では、別 project のリソース識別子を downstream 側で参照する場面が発生する。
+
+例:
+
+- `devgist-app` が `devgist-ops` の `Artifact Registry repository URL` を参照する
+- `devgist-app` が `devgist-data` の `GCS bucket name` を参照する
+- `devgist-app` が `devgist-data` の `Cloud SQL connection name` を参照する
+
+ここで、どの方法で cross-project の値を共有するかを決める必要がある。
+
+### 要件と制約
+
+1. **silent success を避けたい**
+   - 人手転記ミスや古い値の放置で、間違った既存リソースを参照したまま apply が成功する状態は避けたい
+   - upstream の正しい値を downstream が直接参照できる形にしたい
+
+2. **複雑な自動化を避けたい**
+   - 初期フェーズで、CI/script による値同期や tfvars 生成の保守運用は避けたい
+   - Terraform の仕組みの中で依存関係を閉じたい
+
+3. **state 分離は維持したい**
+   - root module と state は引き続き project ごとに分けたい
+   - そのうえで、必要最小限の read 依存だけを許容したい
+
+4. **secret を混ぜない**
+   - secret を Terraform outputs や tfvars で project 間共有しない
+   - secret は `Secret Manager` を正本としたい
+
+5. **IAM を明示管理したい**
+   - remote state の読み取り権限が必要になるため、IAM も Terraform で管理したい
+
+### 比較した選択肢
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: `terraform_remote_state` | upstream を source of truth にして、自動追従したい場合 | 転記不要。upstream 変更に追従しやすい。Terraform 内で閉じる。 | state 間 read 依存が生じる。remote state 読み取り IAM が必要。 | 採用 |
+| Option B: CI/script による自動同期 | 値配布を Terraform 外で自動化したい場合 | state を直接読ませずに済む。 | 自動化自体の保守が必要。初期フェーズには重い。 | 非採用 |
+| Option C: variables + 手動更新 | 単純な構成で人手運用を許容する場合 | 実装が単純。state 間依存がない。 | 値の転記ミス・古い値の残留が起きやすい。silent success を防ぎにくい。 | 非採用 |
+
+### 選定観点
+
+- upstream の値を downstream が誤転記なしに使えるか
+- 複雑な同期自動化なしで運用できるか
+- state 分離を維持しながら依存を明示できるか
+- secret を確実に分離できるか
+- IAM を Terraform で追跡可能にできるか
+
+## Considered Options
+
+### Option A: `terraform_remote_state` を使う [採用]
+
+upstream project の Terraform outputs を downstream project が `terraform_remote_state` で直接読む。
+
+採用理由:
+
+- **転記をなくせる**
+  - `ops` や `data` の output を `app` がそのまま参照できる。
+  - 人手で tfvars や変数にコピーする必要がなく、古い値が残る事故を減らせる。
+
+- **source of truth が明確**
+  - 値の正本は upstream project の Terraform output になる。
+  - downstream 側は値を再定義せず、参照だけに徹することができる。
+
+- **複雑な CI/script が不要**
+  - 値の同期や配布を Terraform 外へ逃がさずに済む。
+  - 個人開発の初期フェーズとして十分シンプルである。
+
+- **state 分離と両立できる**
+  - state 自体は project ごとに独立したまま保ち、必要最小限の read 依存だけを持てる。
+  - `tf -> ops/data -> app` の apply 順序も明示しやすい。
+
+### Option B: CI/script で値を自動同期する [却下]
+
+upstream outputs を CI や wrapper script で収集し、downstream の tfvars などへ自動反映する。
+
+却下理由:
+
+- **自動化の保守コストが高い**
+  - 値の配布ロジック自体を理解・保守する必要がある。
+  - 初期フェーズとしては Terraform 本体より周辺運用が重くなりやすい。
+
+- **source of truth が曖昧になる**
+  - Terraform output ではなく CI/script 側に設計が逃げやすい。
+
+### Option C: variables + 手動更新 [却下]
+
+upstream の値を人手で tfvars や variables に転記し、downstream 側で受ける。
+
+却下理由:
+
+- **silent success のリスクがある**
+  - typo や古い値のままでも、たまたま既存リソースを指していれば apply が通ってしまう可能性がある。
+
+- **正本が分散しやすい**
+  - upstream output と downstream variable のどちらが正か分かりにくくなる。
+
+## Decision (決定事項)
+
+DevGist の cross-project Terraform output 共有戦略として、`terraform_remote_state` を採用する。
+
+### 採用方針
+
+- `terraform_remote_state` の対象は非 secret な infrastructure identifiers に限定する
+  - 例: `Artifact Registry repository URL`, `GCS bucket name`, `Cloud SQL connection name`
+
+- downstream project は upstream project の `outputs` のみに依存する
+  - upstream の内部 resource 名や state 内部構造に直接依存しない
+
+- secret は Terraform outputs で共有しない
+  - `GCP Secret Manager` を正本とする
+  - app project 側のアプリケーションが runtime で `Secret Manager` を読む
+
+- remote state を読むための IAM は Terraform 管理に含める
+  - app の apply 実行主体が、必要な upstream state bucket を read できるようにする
+
+- apply 順序は `tf -> ops/data -> app` を前提とする
+
+### 値の種類ごとのルール
+
+- **非 secret な共有値**
+  - `terraform_remote_state` で upstream outputs を参照する
+
+- **環境差分**
+  - `gcp_project_id`, `region` など、state 共有と関係ない値は従来通り variables で受ける
+
+- **安定した構成値**
+  - `repository_id = "crawler"` など、project 内で完結する固定値は Terraform コードに明示してよい
+
+- **secret**
+  - `Secret Manager` で管理し、Terraform は secret 名や参照権限だけを扱う
+
+### 参考実装
+
+#### `ops` 側で output を公開する
+
+```hcl
+output "crawler_artifact_registry_repository_url" {
+  value       = module.crawler_artifact_registry.repository_url
+  description = "The Docker repository URL for crawler images"
+}
+```
+
+#### `app` 側で `terraform_remote_state` を参照する
+
+```hcl
+data "terraform_remote_state" "ops" {
+  backend = "gcs"
+  config = {
+    bucket = "haru256-devgist-ops-tfstate"
+    prefix = "default"
+  }
+}
+
+locals {
+  crawler_repository_url = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_url
+  crawler_image          = "${local.crawler_repository_url}/crawler:latest"
+}
+```
+
+#### `data` 側の bucket 名を `app` が参照する
+
+```hcl
+data "terraform_remote_state" "data" {
+  backend = "gcs"
+  config = {
+    bucket = "haru256-devgist-data-dev-tfstate"
+    prefix = "default"
+  }
+}
+
+locals {
+  datalake_bucket_name = data.terraform_remote_state.data.outputs.datalake_bucket_name
+}
+```
+
+#### secret は Terraform output で共有せず、アプリケーションが `Secret Manager` を参照する
+
+```python
+from google.cloud import secretmanager
+
+def access_secret(project_id: str, secret_id: str, version: str = "latest") -> str:
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version}"
+    response = client.access_secret_version(request={"name": name})
+    return response.payload.data.decode("utf-8")
+```
+
+### 禁止事項
+
+- secret を Terraform outputs や tfvars で共有すること
+- downstream 側が upstream の内部 resource 名を直接決め打ちすること
+- `terraform_remote_state` を無秩序に増やし、依存方向を曖昧にすること
+
+### 再検討条件
+
+- remote state 読み取り IAM や backend 依存の運用コストが高くなった場合
+- 共有する値の数が増えすぎ、Terraform 間依存が複雑化した場合
+- CI/CD を本格導入し、state 参照より pipeline orchestration の方が合理的になった場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- upstream の正しい値を downstream が直接参照できる
+- 人手転記や tfvars 同期が不要になる
+- 値の正本が Terraform outputs に一本化される
+- 複雑な CI/script 自動化を初期フェーズで避けられる
+
+### Negative (デメリット)
+
+- remote state 読み取り用の cross-project IAM が必要になる
+- backend bucket / prefix への依存が downstream 側に入る
+- apply 順序を守る必要がある
+
+### Risks / Future Review (将来の課題)
+
+- backend 構成変更時に downstream の remote state 設定も追従が必要になる
+- remote state 参照が増えすぎると、project 分離の見通しが悪くなる可能性がある
+- outputs の設計が雑だと、upstream/downstream の境界が曖昧になる
+
+## Next Steps
+
+1. `ops`, `data`, `app` の各 root module で公開すべき非 secret outputs を整理する
+2. `app` 側に `terraform_remote_state` の参照を追加する
+3. remote state 読み取り IAM を Terraform 管理に含める
+4. `infra/README.md` に apply 順序と remote state 参照関係を明記する
+5. secret の runtime 参照方式を `Secret Manager` 前提で整備する
+
+## Related Documents
+
+- [INFRA-ADR-004] Terraform State Project と Ops Project を分離する
+- [INFRA-ADR-005] Terraform environments は GCP project ごとに分割する
+- [ADR運用ガイド](../../../docs/adr/README.md)
+- [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/006-cross-project-output-sharing.md
+++ b/docs/adr/infra/006-cross-project-output-sharing.md
@@ -153,7 +153,7 @@ DevGist の cross-project Terraform output 共有戦略として、`terraform_re
 
 ```hcl
 output "crawler_artifact_registry_repository_url" {
-  value       = module.crawler_artifact_registry.repository_url
+  value       = module.artifact_registries["crawler"].repository_url
   description = "The Docker repository URL for crawler images"
 }
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -17,5 +17,85 @@
 - `INFRA-ADR-001`: [docs/adr/infra/001-gcp-project-structure.md](../docs/adr/infra/001-gcp-project-structure.md)
 - `INFRA-ADR-002`: [docs/adr/infra/002-terraform-module-structure.md](../docs/adr/infra/002-terraform-module-structure.md)
 - `INFRA-ADR-003`: [docs/adr/infra/003-crawler-execution-platform.md](../docs/adr/infra/003-crawler-execution-platform.md)
+- `INFRA-ADR-004`: [docs/adr/infra/004-separate-tf-and-ops-projects.md](../docs/adr/infra/004-separate-tf-and-ops-projects.md)
+- `INFRA-ADR-005`: [docs/adr/infra/005-terraform-environment-slicing.md](../docs/adr/infra/005-terraform-environment-slicing.md)
+- `INFRA-ADR-006`: [docs/adr/infra/006-cross-project-output-sharing.md](../docs/adr/infra/006-cross-project-output-sharing.md)
 
 このディレクトリ配下の `infra/docs/adr/` は互換性維持のための参照パスであり、正本は [docs/adr/](../docs/adr/) 側です。
+
+## Current GCP Project Responsibilities
+
+現時点の想定 GCP project 構成は、`tf` と `ops` を分離した 4 系統です。
+
+```mermaid
+graph TD
+    TF[haru256-devgist-tf<br/>Terraform state only]
+    OPS[haru256-devgist-ops<br/>Artifact Registry / CI-CD]
+    DATA[haru256-devgist-data-{env}<br/>Stateful data]
+    APP[haru256-devgist-app-{env}<br/>Stateless compute]
+
+    OPS --> APP
+    APP --> DATA
+```
+
+- `haru256-devgist-tf`
+  - Terraform state bucket 専用 project
+  - 原則として tfstate 管理以外の常設リソースは置かない
+
+- `haru256-devgist-ops`
+  - Artifact Registry
+  - GitHub Actions 連携、WIF、共通 CI/CD 用 Service Account などの運用基盤
+
+- `haru256-devgist-data-{env}`
+  - GCS datalake
+  - Cloud SQL / BigQuery など stateful data
+
+- `haru256-devgist-app-{env}`
+  - Cloud Run Jobs
+  - frontend / backend API など stateless compute
+
+### Responsibility Notes
+
+- crawler の image store は `ops` project 側の `Artifact Registry` に置く
+- crawler の実行先は `app` project 側の `Cloud Run Jobs` とする
+- crawler の保存先 datalake は `data` project 側に置く
+- project 構成の判断根拠は `INFRA-ADR-001` から `INFRA-ADR-006` を参照する
+
+## Service To Project Mapping
+
+`crawler` は 1 つの environment に閉じず、`ops / app / data` の各 project に責務を分解して配置します。
+
+| Service | Project | Responsibility | Source of Truth |
+|---|---|---|---|
+| `crawler` | `haru256-devgist-ops` | `Artifact Registry` repository | `devgist-ops` Terraform state |
+| `crawler` | `haru256-devgist-app-dev` | `Cloud Run Jobs` / app runtime | `devgist-app/dev` Terraform state |
+| `crawler` | `haru256-devgist-data-dev` | `GCS datalake` などの保存先 | `devgist-data/dev` Terraform state |
+
+## Terraform Apply Order
+
+project ごとに state を分けているため、`crawler` 関連の apply は依存順に実行します。
+
+```mermaid
+graph LR
+    TF[devgist-tf] --> OPS[devgist-ops]
+    TF --> DATA[devgist-data/dev]
+    OPS --> APP[devgist-app/dev]
+    DATA --> APP
+```
+
+### Order
+
+1. `devgist-tf`
+   - tfstate bucket を先に作成する
+2. `devgist-ops`
+   - `Artifact Registry` など共通運用基盤を作成する
+3. `devgist-data/dev`
+   - datalake など crawler の保存先を作成する
+4. `devgist-app/dev`
+   - `terraform_remote_state` で `ops/data` の outputs を参照しながら app 側 compute を作成する
+
+### Notes
+
+- `devgist-app/dev` は `devgist-ops` と `devgist-data/dev` の outputs を `terraform_remote_state` で参照する
+- secret は Terraform outputs では渡さず、`GCP Secret Manager` を app runtime から参照する
+- 旧 `environments/crawler` は legacy 扱いで、最終的には `ops/app/data` 側へ整理する

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -20,24 +20,51 @@ infra/terraform/
 ├── README.md
 ├── environments/
 │   ├── .gitignore
-│   └── dev/
-│       ├── crawler/
-│       │   ├── Makefile
-│       │   ├── backend.tf
-│       │   ├── main.tf
-│       │   ├── outputs.tf
-│       │   ├── providers.tf
-│       │   ├── terraform.tfstate
-│       │   ├── terraform.tfvars
-│       │   └── variables.tf
-│       └── tfstate/
-│           ├── backend.tf
-│           ├── main.tf
-│           ├── outputs.tf
-│           ├── providers.tf
-│           ├── variables.tf
-│           └── terraform.tfvars
+│   ├── devgist-app/
+│   │   └── dev/
+│   │       ├── Makefile
+│   │       ├── backend.tf
+│   │       ├── config.gcs.tfbackend
+│   │       ├── main.tf
+│   │       ├── outputs.tf
+│   │       ├── providers.tf
+│   │       ├── terraform.tfvars
+│   │       └── variables.tf
+│   ├── devgist-data/
+│   │   └── dev/
+│   │       ├── Makefile
+│   │       ├── backend.tf
+│   │       ├── config.gcs.tfbackend
+│   │       ├── main.tf
+│   │       ├── outputs.tf
+│   │       ├── providers.tf
+│   │       ├── terraform.tfvars
+│   │       └── variables.tf
+│   ├── devgist-ops/
+│   │   ├── Makefile
+│   │   ├── backend.tf
+│   │   ├── config.gcs.tfbackend
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── terraform.tfvars
+│   │   └── variables.tf
+│   └── devgist-tf/
+│       ├── Makefile
+│       ├── backend.tf
+│       ├── config.gcs.tfbackend
+│       ├── main.tf
+│       ├── outputs.tf
+│       ├── providers.tf
+│       ├── terraform.tfvars
+│       └── variables.tf
 ├── modules/
+│   ├── artifact_registry/
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── variables.tf
+│   │   └── README.md
 │   ├── datalake/
 │   │   ├── main.tf
 │   │   ├── outputs.tf
@@ -62,14 +89,17 @@ infra/terraform/
 
 ### `environments/`
 環境ごとの root module を配置します。  
-`dev/` 配下に環境別の構成を置き、さらにサービス単位で分割しています。
+GCP project ごとに root module を配置し、必要に応じて `dev/` などの環境サブディレクトリを切ります。
 
-- `dev/crawler/`: 開発環境の crawler 用 root module
-- `dev/tfstate/`: Terraform state 管理用インフラを構築する root module
+- `devgist-tf/`: Terraform state 管理用 project の root module
+- `devgist-ops/`: Artifact Registry などの共通運用基盤 project の root module
+- `devgist-data/dev/`: 開発環境の data project 用 root module
+- `devgist-app/dev/`: 開発環境の app project 用 root module
 
 ### `modules/`
 複数の環境で再利用する module を配置します。
 
+- `artifact_registry/`: Artifact Registry repository を作成する module
 - `datalake/`: GCP のデータレイク用 GCS バケットを作成する module
 - `google_project_services/`: GCP の API 有効化を行う module
 - `tfstate_gcs_bucket/`: Terraform の state 管理用 GCS バケットを作成する module

--- a/infra/terraform/environments/crawler/main.tf
+++ b/infra/terraform/environments/crawler/main.tf
@@ -14,7 +14,7 @@ data "google_project" "project" {
 module "required_project_services" {
   source = "../../modules/google_project_services"
 
-  project_id        = var.gcp_project_id
+  project_id        = data.google_project.project.project_id
   required_services = local.required_services
   wait_seconds      = 30
 }

--- a/infra/terraform/environments/crawler/main.tf
+++ b/infra/terraform/environments/crawler/main.tf
@@ -12,16 +12,9 @@ data "google_project" "project" {
 
 # 必要なAPIをすべて有効化し待機
 module "required_project_services" {
-  source = "../../../modules/google_project_services"
+  source = "../../modules/google_project_services"
 
   project_id        = var.gcp_project_id
   required_services = local.required_services
   wait_seconds      = 30
-}
-
-# create the bucket for terraform state
-module "tfstate_bucket" {
-  source         = "../../../modules/tfstate_gcs_bucket"
-  gcp_project_id = data.google_project.project.project_id
-  depends_on     = [module.required_project_services]
 }

--- a/infra/terraform/environments/devgist-app/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-app/dev/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
+    "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
+    "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
+    "zh:60c96075fc082d9584b9cb8f48f0d23f90fd4344e6141a417580c6bad1b21957",
+    "zh:ad82cece07a0816153e3fc6cb6d7672c6c009742dc802ab434a83d0731d94ae7",
+    "zh:aebbf8a0bd3af0b6c705d5d85ec51891f533b83dcbae7249e64a252efc6fd862",
+    "zh:bfbb19a5b46950eaf0a83cea09a5992d1b0e96792130faeb6c733609dc2913df",
+    "zh:c196b4c82d0252fa751ee3cd84433bc483b7ce7d6fcab5db0413dbaa9f218650",
+    "zh:db1c83777bc6d7fc195be83712a9f503e9a5a1f7326fd6968d9812acc53f2056",
+    "zh:dcd58beeac9d1889e5532cfcd3bd8dec5568ab06b0a81427bc9b35931b6f0178",
+    "zh:eaeedc86c2d01630a3166ae98d5138e9bf9463b2a606d7f7df6d465d1501f28f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
+    "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
+    "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
+    "zh:5064a8ffda6f8c6b5e72842623a6dc433fd8d8e4013f9266e2636e140a674f6a",
+    "zh:5f383784682442c67a145c4c9117864da735b149aa0e6feefb7f5c0eab738e63",
+    "zh:7fb9526dfeae6e9edd61badfd2c6c64e690e332330a88ccc8deb837d8d08cfc7",
+    "zh:84d707e934b4a2d5bf8ff6ef4758328c93ece119e5fcda09686f47db4fb68e84",
+    "zh:9aab258c4a614f2c05468893891ba6af517c448389ad080831f12f4d52048646",
+    "zh:9f8d8d7c11697b36c0f5d4e54882d7448923bb8d5083a1e50ed63043cb60dda6",
+    "zh:ad9a5a714e60f31f2576b246ac6852b3423ed62ee9537cbabf7fd147207f9e77",
+    "zh:c1098525b4a7fa8aa39cef056718c0f176842defb7dc284bc66148377d5d125d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9b705921562316bdf89e2fb310c036d3cc7bb3bf973fef318da0888deea82fa",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/infra/terraform/environments/devgist-app/dev/Makefile
+++ b/infra/terraform/environments/devgist-app/dev/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+TFLINT_CONFIG := ../../../.tflint.hcl
+include ../../../scripts/common.mk
+
+.PHONY: init
+init: # initialize terraform
+	terraform init -backend-config=config.gcs.tfbackend
+
+.PHONY: plan
+plan: # plan terraform
+	terraform plan
+
+.PHONY: apply
+apply: # apply terraform
+	terraform apply
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -h -E '^[a-zA-Z0-9 -]+:.*#' $(MAKEFILE_LIST) | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done

--- a/infra/terraform/environments/devgist-app/dev/backend.tf
+++ b/infra/terraform/environments/devgist-app/dev/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  # partial backend configurationで指定するため、ここでは空を設定
+  backend "gcs" {}
+}

--- a/infra/terraform/environments/devgist-app/dev/config.gcs.tfbackend
+++ b/infra/terraform/environments/devgist-app/dev/config.gcs.tfbackend
@@ -1,0 +1,1 @@
+bucket = "haru256-devgist-app-dev-tfstate"

--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -1,0 +1,18 @@
+locals {
+  # このTerraform構成で必要な全APIをリスト化
+  required_services = [
+    "run.googleapis.com", # Cloud Run Jobs / Services
+  ]
+}
+
+data "google_project" "project" {
+  project_id = var.gcp_project_id
+}
+
+module "required_project_services" {
+  source = "../../../modules/google_project_services"
+
+  project_id        = data.google_project.project.project_id
+  required_services = local.required_services
+  wait_seconds      = 30
+}

--- a/infra/terraform/environments/devgist-app/dev/outputs.tf
+++ b/infra/terraform/environments/devgist-app/dev/outputs.tf
@@ -1,0 +1,4 @@
+output "app_project_id" {
+  value       = data.google_project.project.project_id
+  description = "The GCP project ID managed by the app environment"
+}

--- a/infra/terraform/environments/devgist-app/dev/providers.tf
+++ b/infra/terraform/environments/devgist-app/dev/providers.tf
@@ -1,0 +1,23 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>7.18.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>7.18.0"
+    }
+  }
+}

--- a/infra/terraform/environments/devgist-app/dev/variables.tf
+++ b/infra/terraform/environments/devgist-app/dev/variables.tf
@@ -1,0 +1,9 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "The ID of GCP project"
+}
+
+variable "gcp_default_region" {
+  type        = string
+  description = "The name of GCP default region"
+}

--- a/infra/terraform/environments/devgist-ops/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-ops/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
+    "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
+    "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
+    "zh:60c96075fc082d9584b9cb8f48f0d23f90fd4344e6141a417580c6bad1b21957",
+    "zh:ad82cece07a0816153e3fc6cb6d7672c6c009742dc802ab434a83d0731d94ae7",
+    "zh:aebbf8a0bd3af0b6c705d5d85ec51891f533b83dcbae7249e64a252efc6fd862",
+    "zh:bfbb19a5b46950eaf0a83cea09a5992d1b0e96792130faeb6c733609dc2913df",
+    "zh:c196b4c82d0252fa751ee3cd84433bc483b7ce7d6fcab5db0413dbaa9f218650",
+    "zh:db1c83777bc6d7fc195be83712a9f503e9a5a1f7326fd6968d9812acc53f2056",
+    "zh:dcd58beeac9d1889e5532cfcd3bd8dec5568ab06b0a81427bc9b35931b6f0178",
+    "zh:eaeedc86c2d01630a3166ae98d5138e9bf9463b2a606d7f7df6d465d1501f28f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
+    "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
+    "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
+    "zh:5064a8ffda6f8c6b5e72842623a6dc433fd8d8e4013f9266e2636e140a674f6a",
+    "zh:5f383784682442c67a145c4c9117864da735b149aa0e6feefb7f5c0eab738e63",
+    "zh:7fb9526dfeae6e9edd61badfd2c6c64e690e332330a88ccc8deb837d8d08cfc7",
+    "zh:84d707e934b4a2d5bf8ff6ef4758328c93ece119e5fcda09686f47db4fb68e84",
+    "zh:9aab258c4a614f2c05468893891ba6af517c448389ad080831f12f4d52048646",
+    "zh:9f8d8d7c11697b36c0f5d4e54882d7448923bb8d5083a1e50ed63043cb60dda6",
+    "zh:ad9a5a714e60f31f2576b246ac6852b3423ed62ee9537cbabf7fd147207f9e77",
+    "zh:c1098525b4a7fa8aa39cef056718c0f176842defb7dc284bc66148377d5d125d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9b705921562316bdf89e2fb310c036d3cc7bb3bf973fef318da0888deea82fa",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/infra/terraform/environments/devgist-ops/Makefile
+++ b/infra/terraform/environments/devgist-ops/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+TFLINT_CONFIG := ../../.tflint.hcl
+include ../../scripts/common.mk
+
+.PHONY: init
+init: # initialize terraform
+	terraform init -backend-config=config.gcs.tfbackend
+
+.PHONY: plan
+plan: # plan terraform
+	terraform plan
+
+.PHONY: apply
+apply: # apply terraform
+	terraform apply
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -h -E '^[a-zA-Z0-9 -]+:.*#' $(MAKEFILE_LIST) | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done

--- a/infra/terraform/environments/devgist-ops/backend.tf
+++ b/infra/terraform/environments/devgist-ops/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  # partial backend configurationで指定するため、ここでは空を設定
+  backend "gcs" {}
+}

--- a/infra/terraform/environments/devgist-ops/config.gcs.tfbackend
+++ b/infra/terraform/environments/devgist-ops/config.gcs.tfbackend
@@ -1,0 +1,1 @@
+bucket = "haru256-devgist-ops-tfstate"

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -1,0 +1,30 @@
+locals {
+  # このTerraform構成で必要な全APIをリスト化
+  required_services = [
+    "artifactregistry.googleapis.com", # Artifact Registry
+  ]
+}
+
+data "google_project" "project" {
+  project_id = var.gcp_project_id
+}
+
+module "required_project_services" {
+  source = "../../modules/google_project_services"
+
+  project_id        = data.google_project.project.project_id
+  required_services = local.required_services
+  wait_seconds      = 30
+}
+
+// crawler用のArtifact Registryを作成
+module "crawler_artifact_registry" {
+  source = "../../modules/artifact_registry"
+
+  project_id    = data.google_project.project.project_id
+  location      = var.gcp_default_region
+  repository_id = "crawler"
+  description   = "Docker images for the crawler job"
+
+  depends_on = [module.required_project_services]
+}

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -3,6 +3,12 @@ locals {
   required_services = [
     "artifactregistry.googleapis.com", # Artifact Registry
   ]
+
+  artifact_registries = {
+    crawler = {
+      description = "Docker images for the crawler job"
+    }
+  }
 }
 
 data "google_project" "project" {
@@ -17,14 +23,21 @@ module "required_project_services" {
   wait_seconds      = 30
 }
 
-// crawler用のArtifact Registryを作成
-module "crawler_artifact_registry" {
+// project 内で利用する Docker 用 Artifact Registry を作成
+module "artifact_registries" {
+  for_each = local.artifact_registries
+
   source = "../../modules/artifact_registry"
 
   project_id    = data.google_project.project.project_id
   location      = var.gcp_default_region
-  repository_id = "crawler"
-  description   = "Docker images for the crawler job"
+  repository_id = each.key
+  description   = each.value.description
 
   depends_on = [module.required_project_services]
+}
+
+moved {
+  from = module.crawler_artifact_registry
+  to   = module.artifact_registries["crawler"]
 }

--- a/infra/terraform/environments/devgist-ops/outputs.tf
+++ b/infra/terraform/environments/devgist-ops/outputs.tf
@@ -1,0 +1,14 @@
+output "ops_project_id" {
+  value       = data.google_project.project.project_id
+  description = "The GCP project ID managed by the ops environment"
+}
+
+output "crawler_artifact_registry_repository_id" {
+  value       = module.crawler_artifact_registry.repository_id
+  description = "The Artifact Registry repository ID for crawler images"
+}
+
+output "crawler_artifact_registry_repository_url" {
+  value       = module.crawler_artifact_registry.repository_url
+  description = "The Docker repository URL for crawler images"
+}

--- a/infra/terraform/environments/devgist-ops/outputs.tf
+++ b/infra/terraform/environments/devgist-ops/outputs.tf
@@ -3,12 +3,22 @@ output "ops_project_id" {
   description = "The GCP project ID managed by the ops environment"
 }
 
+output "artifact_registry_repository_ids" {
+  value       = { for key, module_instance in module.artifact_registries : key => module_instance.repository_id }
+  description = "Artifact Registry repository IDs keyed by repository name"
+}
+
+output "artifact_registry_repository_urls" {
+  value       = { for key, module_instance in module.artifact_registries : key => module_instance.repository_url }
+  description = "Docker repository URLs keyed by repository name"
+}
+
 output "crawler_artifact_registry_repository_id" {
-  value       = module.crawler_artifact_registry.repository_id
+  value       = module.artifact_registries["crawler"].repository_id
   description = "The Artifact Registry repository ID for crawler images"
 }
 
 output "crawler_artifact_registry_repository_url" {
-  value       = module.crawler_artifact_registry.repository_url
+  value       = module.artifact_registries["crawler"].repository_url
   description = "The Docker repository URL for crawler images"
 }

--- a/infra/terraform/environments/devgist-ops/providers.tf
+++ b/infra/terraform/environments/devgist-ops/providers.tf
@@ -1,0 +1,23 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_default_region
+}
+
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>7.18.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>7.18.0"
+    }
+  }
+}

--- a/infra/terraform/environments/devgist-ops/variables.tf
+++ b/infra/terraform/environments/devgist-ops/variables.tf
@@ -1,0 +1,9 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "The ID of GCP project"
+}
+
+variable "gcp_default_region" {
+  type        = string
+  description = "The name of GCP default region"
+}

--- a/infra/terraform/modules/artifact_registry/README.md
+++ b/infra/terraform/modules/artifact_registry/README.md
@@ -1,6 +1,6 @@
 # artifact_registry
 
-GCP の `Artifact Registry repository` を作成するモジュールです。
+GCP の Docker 用 `Artifact Registry repository` を作成するモジュールです。
 
 このモジュールは単一の repository を作ることだけを責務に持ちます。DevGist では project は共有しつつ、application / service ごとに repository を分けて運用する前提で使います。
 
@@ -16,7 +16,6 @@ GCP の `Artifact Registry repository` を作成するモジュールです。
 | `location` | repository のリージョン | `string` | n/a | yes |
 | `repository_id` | repository ID | `string` | n/a | yes |
 | `description` | repository の説明 | `string` | `""` | no |
-| `format` | repository の package format | `string` | `"DOCKER"` | no |
 
 ## Outputs
 
@@ -30,12 +29,24 @@ GCP の `Artifact Registry repository` を作成するモジュールです。
 ## Usage
 
 ```hcl
-module "crawler_artifact_registry" {
-  source = "../../../modules/artifact_registry"
+locals {
+  artifact_registries = {
+    crawler = {
+      description = "Docker images for the crawler job"
+    }
+    api = {
+      description = "Docker images for the API service"
+    }
+  }
+}
+
+module "artifact_registries" {
+  for_each = local.artifact_registries
+  source   = "../../../modules/artifact_registry"
 
   project_id    = var.gcp_project_id
   location      = var.gcp_default_region
-  repository_id = "crawler"
-  description   = "Docker images for the crawler job"
+  repository_id = each.key
+  description   = each.value.description
 }
 ```

--- a/infra/terraform/modules/artifact_registry/README.md
+++ b/infra/terraform/modules/artifact_registry/README.md
@@ -1,0 +1,41 @@
+# artifact_registry
+
+GCP の `Artifact Registry repository` を作成するモジュールです。
+
+このモジュールは単一の repository を作ることだけを責務に持ちます。DevGist では project は共有しつつ、application / service ごとに repository を分けて運用する前提で使います。
+
+## Resources
+
+- `google_artifact_registry_repository.repository`
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `project_id` | repository を作成する GCP Project ID | `string` | n/a | yes |
+| `location` | repository のリージョン | `string` | n/a | yes |
+| `repository_id` | repository ID | `string` | n/a | yes |
+| `description` | repository の説明 | `string` | `""` | no |
+| `format` | repository の package format | `string` | `"DOCKER"` | no |
+
+## Outputs
+
+| Name | Description | Type |
+|------|-------------|------|
+| `repository_id` | Artifact Registry repository ID | `string` |
+| `name` | Artifact Registry repository resource name | `string` |
+| `location` | Artifact Registry repository location | `string` |
+| `repository_url` | Docker push 用 URL | `string` |
+
+## Usage
+
+```hcl
+module "crawler_artifact_registry" {
+  source = "../../../modules/artifact_registry"
+
+  project_id    = var.gcp_project_id
+  location      = var.gcp_default_region
+  repository_id = "crawler"
+  description   = "Docker images for the crawler job"
+}
+```

--- a/infra/terraform/modules/artifact_registry/main.tf
+++ b/infra/terraform/modules/artifact_registry/main.tf
@@ -3,5 +3,5 @@ resource "google_artifact_registry_repository" "repository" {
   location      = var.location
   repository_id = var.repository_id
   description   = var.description
-  format        = var.format
+  format        = "DOCKER"
 }

--- a/infra/terraform/modules/artifact_registry/main.tf
+++ b/infra/terraform/modules/artifact_registry/main.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "repository" {
+  project       = var.project_id
+  location      = var.location
+  repository_id = var.repository_id
+  description   = var.description
+  format        = var.format
+}

--- a/infra/terraform/modules/artifact_registry/outputs.tf
+++ b/infra/terraform/modules/artifact_registry/outputs.tf
@@ -1,0 +1,19 @@
+output "repository_id" {
+  description = "The Artifact Registry repository ID."
+  value       = google_artifact_registry_repository.repository.repository_id
+}
+
+output "name" {
+  description = "The full resource name of the Artifact Registry repository."
+  value       = google_artifact_registry_repository.repository.name
+}
+
+output "location" {
+  description = "The Artifact Registry repository location."
+  value       = google_artifact_registry_repository.repository.location
+}
+
+output "repository_url" {
+  description = "The Docker push URL for the Artifact Registry repository."
+  value       = "${google_artifact_registry_repository.repository.location}-docker.pkg.dev/${google_artifact_registry_repository.repository.project}/${google_artifact_registry_repository.repository.repository_id}"
+}

--- a/infra/terraform/modules/artifact_registry/providers.tf
+++ b/infra/terraform/modules/artifact_registry/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>7.18.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>7.18.0"
+    }
+  }
+}

--- a/infra/terraform/modules/artifact_registry/variables.tf
+++ b/infra/terraform/modules/artifact_registry/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID where the Artifact Registry repository is created."
+}
+
+variable "location" {
+  type        = string
+  description = "The regional location for the Artifact Registry repository."
+}
+
+variable "repository_id" {
+  type        = string
+  description = "The Artifact Registry repository ID."
+}
+
+variable "description" {
+  type        = string
+  description = "The description for the Artifact Registry repository."
+  default     = ""
+}
+
+variable "format" {
+  type        = string
+  description = "The package format for the Artifact Registry repository."
+  default     = "DOCKER"
+}

--- a/infra/terraform/modules/artifact_registry/variables.tf
+++ b/infra/terraform/modules/artifact_registry/variables.tf
@@ -18,9 +18,3 @@ variable "description" {
   description = "The description for the Artifact Registry repository."
   default     = ""
 }
-
-variable "format" {
-  type        = string
-  description = "The package format for the Artifact Registry repository."
-  default     = "DOCKER"
-}

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-python = "3.12.12"
-terraform = "1.14.5"
+python = "3.14.4"
+terraform = "1.14.8"
 terraform-docs = "latest"
 tflint = "0.61.0"
-trivy = "0.69.1"
-uv = "0.10.4"
+trivy = "0.70.0"
+uv = "0.11.7"

--- a/workflows/crawler/README.md
+++ b/workflows/crawler/README.md
@@ -65,6 +65,32 @@ graph TD
 6. **GCS Datalakeへの保存**
    - 補完済み論文を JSONL 形式でバッチ分割してアップロード
 
+## GCP での実行構成
+
+`crawler` の実行基盤は、関連 ADR に合わせて `Cloud Run Jobs` を前提とします。初期運用では GitHub Actions でコンテナイメージをビルドして `Artifact Registry` に配置し、手動で `Cloud Run Jobs` を実行して、収集結果を `GCS` に保存します。
+
+```mermaid
+graph LR
+    Dev[Developer] --> GitHub[GitHub Repository]
+    GitHub --> GHA[GitHub Actions<br/>Manual workflow dispatch]
+    GHA --> Build[Build crawler image]
+    Build --> AR[Artifact Registry]
+    AR --> CRJ[Cloud Run Jobs<br/>crawler execution]
+    Operator[Operator / Manual trigger] --> CRJ
+    CRJ --> APIs[External source APIs<br/>DBLP / Semantic Scholar / Unpaywall / arXiv]
+    APIs --> CRJ
+    CRJ --> GCS[GCS Datalake<br/>JSONL]
+    CRJ --> Logs[Cloud Logging / Monitoring]
+```
+
+### 構成メモ
+
+- CI/CD は `GitHub Actions` の手動トリガー（`workflow_dispatch`）から開始する
+- コンテナイメージは `Artifact Registry` に保存し、`Cloud Run Jobs` から参照する
+- crawler は HTTP サービスではなく完了まで走るバッチなので、`Cloud Run Service` ではなく `Cloud Run Jobs` を使う
+- 収集データの保存先は `GCS` をデータレイクとして使う
+- 将来定期実行へ移行する場合は、`Cloud Scheduler` を `Cloud Run Jobs` の起動元として追加する
+
 ## ディレクトリ構成
 
 ```text


### PR DESCRIPTION
## Summary
crawler 向けインフラの GCP project 境界に合わせて、Terraform 構成と関連ドキュメントを再編する PR です。

## Related Issues
N/A

## Changes
- `tf` project と `ops` project の分離、Terraform environment の GCP project 単位への再編、`terraform_remote_state` による cross-project 参照方針を ADR として追加
- GCP project の責務、Terraform apply 順序、crawler 実行フローを `infra/README.md` と `workflows/crawler/README.md` に追記
- 再利用可能な `artifact_registry` Terraform module を追加し、`devgist-ops` と `devgist-app/dev` の project 単位 environment を追加
- Terraform 関連 README と `devgist-tf` 設定を、新しい project-oriented な構成に合わせて更新

## How to Test
- `terraform -chdir=infra/terraform/environments/devgist-ops init -backend=false`
- `terraform -chdir=infra/terraform/environments/devgist-ops validate`
- `terraform -chdir=infra/terraform/environments/devgist-app/dev init -backend=false`
- `terraform -chdir=infra/terraform/environments/devgist-app/dev validate`
- `terraform -chdir=infra/terraform/environments/devgist-tf init -backend=false`
- `terraform -chdir=infra/terraform/environments/devgist-tf validate`

## Additional Context
- `infra/terraform/environments/crawler` は legacy environment として残しており、その旨を README に明記しています。
