### PR TITLE
feat(infra): crawlerサービスアカウントにdatalake GCSバケットのIAM権限を付与

### DIFF
--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -23,6 +23,15 @@ data "terraform_remote_state" "ops" {
   }
 }
 
+// data 環境の Terraform state から、data 環境で作成したリソースの情報を参照するための data source
+data "terraform_remote_state" "data" {
+  backend = "gcs"
+
+  config = {
+    bucket = "haru256-devgist-data-dev-tfstate"
+  }
+}
+
 module "required_project_services" {
   source = "../../../modules/google_project_services"
 
@@ -46,10 +55,24 @@ module "service_accounts" {
   depends_on = [module.required_project_services]
 }
 
-resource "google_artifact_registry_repository_iam_member" "crawler_reader" {
+// ops 環境の Artifact Registry に対して、dev 環境の crawler 用 service account に reader 権限を付与
+resource "google_artifact_registry_repository_iam_member" "crawler" {
   project    = data.terraform_remote_state.ops.outputs.ops_project_id
   location   = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_location
   repository = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_id
   role       = "roles/artifactregistry.reader"
   member     = module.service_accounts.members["crawler"]
+}
+moved {
+  from = google_artifact_registry_repository_iam_member.crawler_reader
+  to   = google_artifact_registry_repository_iam_member.crawler
+}
+
+// data環境のGCSバケットに対して、dev環境のcrawler用service accountに読み込み・書き込み権限を付与
+resource "google_storage_bucket_iam_member" "crawler" {
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
+
+  bucket = data.terraform_remote_state.data.outputs.datalake_bucket_name
+  role   = each.value
+  member = module.service_accounts.members["crawler"]
 }

--- a/infra/terraform/environments/devgist-data/dev/outputs.tf
+++ b/infra/terraform/environments/devgist-data/dev/outputs.tf
@@ -1,1 +1,4 @@
-
+output "datalake_bucket_name" {
+  description = "Name of the datalake GCS bucket"
+  value       = module.data_platform.datalake_bucket_name
+}


### PR DESCRIPTION
## Summary

- `devgist-data/dev` の terraform remote state を参照する data source を追加し、datalake バケット名を取得
- `devgist-data/dev/outputs.tf` に `datalake_bucket_name` output を追加
- crawler SA に `roles/storage.objectViewer` + `roles/storage.objectCreator` を付与（datalakeへの読み書き）
- `google_artifact_registry_repository_iam_member` を `crawler_reader` → `crawler` にリネーム（`moved` ブロックで state 破壊を回避）

## Test Plan

- [ ] `devgist-data/dev` で `terraform plan` を実行し、output追加のみであることを確認
- [ ] `devgist-app/dev` で `terraform plan` を実行し、IAMリソースの追加と `moved` による差分なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)