### PR TITLE
feat(ci): terraform module の lint を全モジュール対象に拡張

### DIFF
--- a/.github/actions/terraform-check/action.yml
+++ b/.github/actions/terraform-check/action.yml
@@ -1,26 +1,26 @@
-name: 'Terraform Check'
-description: 'Run Terraform init, validate, test, and TFLint for a single root'
+name: "Terraform Check"
+description: "Run Terraform init, validate, test, and TFLint for a single root"
 
 inputs:
   working-directory:
-    description: 'Terraform root directory'
+    description: "Terraform root directory"
     required: true
   terraform-version:
-    description: 'Terraform version'
+    description: "Terraform version"
     required: false
-    default: '1.14.8'
+    default: "1.14.8"
   tflint-config:
-    description: 'Path to tflint config from repo root'
+    description: "Path to tflint config from repo root"
     required: false
-    default: 'infra/terraform/.tflint.hcl'
+    default: "infra/terraform/.tflint.hcl"
   tflint-version:
-    description: 'TFLint version'
+    description: "TFLint version"
     required: false
-    default: 'v0.61.0'
+    default: "v0.61.0"
   skip-validate:
-    description: 'Skip terraform validate step'
+    description: "Skip terraform validate step"
     required: false
-    default: 'false'
+    default: "false"
 
 runs:
   using: "composite"

--- a/.github/scripts/find_terraform_roots.py
+++ b/.github/scripts/find_terraform_roots.py
@@ -6,7 +6,8 @@ This script detects two Terraform CI target groups under ``--terraform-dir``:
 * ``environment_roots``: directories under ``environments/`` that contain
   ``providers.tf``. These roots run init, validate, optional test, and tflint.
 * ``module_roots``: module directories under ``modules/`` that contain
-  ``providers.tf``. These roots run init and tflint without validate.
+  ``providers.tf``. These roots run init and tflint without validate, and
+  also run ``terraform test`` when ``*.tftest.hcl`` files are present.
 
 It writes the following key/value pairs to ``$GITHUB_OUTPUT`` when running in
 GitHub Actions, and prints the same key/value pairs to stdout for local use:

--- a/.github/scripts/find_terraform_roots.py
+++ b/.github/scripts/find_terraform_roots.py
@@ -5,14 +5,13 @@ This script detects two Terraform CI target groups under ``--terraform-dir``:
 
 * ``environment_roots``: directories under ``environments/`` that contain
   ``providers.tf``. These roots run init, validate, optional test, and tflint.
-* ``module_test_roots``: module directories under ``modules/`` that contain
-  ``*.tftest.hcl`` files. If a test file is in ``tests/``, the parent module
-  directory is used as the root. These roots run module tests without validate.
+* ``module_roots``: module directories under ``modules/`` that contain
+  ``providers.tf``. These roots run init and tflint without validate.
 
 It writes the following key/value pairs to ``$GITHUB_OUTPUT`` when running in
 GitHub Actions, and prints the same key/value pairs to stdout for local use:
-``environment_roots``, ``environment_roots_count``, ``module_test_roots``, and
-``module_test_roots_count``.
+``environment_roots``, ``environment_roots_count``, ``module_roots``, and
+``module_roots_count``.
 """
 
 from __future__ import annotations
@@ -39,21 +38,14 @@ def find_environment_roots(terraform_dir: Path) -> list[Path]:
     )
 
 
-def module_root_for_test(test_file: Path) -> Path:
-    for parent in test_file.parents:
-        if parent.name == "tests":
-            return parent.parent
-    return test_file.parent
-
-
-def find_module_test_roots(terraform_dir: Path) -> list[Path]:
+def find_module_roots(terraform_dir: Path) -> list[Path]:
     modules_dir = terraform_dir / "modules"
     if not modules_dir.exists():
         return []
 
     roots = {
-        module_root_for_test(path)
-        for path in modules_dir.rglob("*.tftest.hcl")
+        path.parent
+        for path in modules_dir.rglob("providers.tf")
         if ".terraform" not in path.parts
     }
     return sorted(roots)
@@ -87,21 +79,21 @@ def main() -> None:
     terraform_dir = args.terraform_dir
 
     environment_roots = find_environment_roots(terraform_dir)
-    module_test_roots = find_module_test_roots(terraform_dir)
+    module_roots = find_module_roots(terraform_dir)
 
     values = {
         "environment_roots": to_json(environment_roots),
         "environment_roots_count": str(len(environment_roots)),
-        "module_test_roots": to_json(module_test_roots),
-        "module_test_roots_count": str(len(module_test_roots)),
+        "module_roots": to_json(module_roots),
+        "module_roots_count": str(len(module_roots)),
     }
     write_github_output(values)
 
     print(f"Terraform environment roots: {values['environment_roots']}")
-    print(f"Terraform module test roots: {values['module_test_roots']}")
+    print(f"Terraform module roots: {values['module_roots']}")
 
-    if not environment_roots and not module_test_roots:
-        raise SystemExit("No Terraform environment or module test roots found.")
+    if not environment_roots and not module_roots:
+        raise SystemExit("No Terraform environment or module roots found.")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_find_terraform_roots.py
+++ b/.github/scripts/tests/test_find_terraform_roots.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from find_terraform_roots import find_environment_roots, find_module_test_roots
+from find_terraform_roots import find_environment_roots, find_module_roots
 
 
 def touch(path: Path) -> None:
@@ -16,7 +16,14 @@ class TestFindEnvironmentRoots:
         # Arrange
         touch(tmp_path / "environments" / "devgist-app" / "dev" / "providers.tf")
         touch(tmp_path / "environments" / "devgist-data" / "dev" / "providers.tf")
-        touch(tmp_path / "environments" / "devgist-app" / "dev" / ".terraform" / "providers.tf")
+        touch(
+            tmp_path
+            / "environments"
+            / "devgist-app"
+            / "dev"
+            / ".terraform"
+            / "providers.tf"
+        )
 
         # Act
         roots = find_environment_roots(tmp_path)
@@ -31,31 +38,22 @@ class TestFindEnvironmentRoots:
         assert find_environment_roots(tmp_path) == []
 
 
-class TestFindModuleTestRoots:
-    def test_finds_module_tests(self, tmp_path: Path) -> None:
+class TestFindModuleRoots:
+    def test_finds_module(self, tmp_path: Path) -> None:
         # Arrange
-        touch(tmp_path / "modules" / "service_accounts" / "tests" / "variables.tftest.hcl")
+        touch(tmp_path / "modules" / "service_accounts" / "providers.tf")
         touch(tmp_path / "modules" / "artifact_registry" / "basic.tftest.hcl")
-        touch(tmp_path / "modules" / "data_platform" / ".terraform" / "ignored.tftest.hcl")
+        touch(
+            tmp_path / "modules" / "data_platform" / ".terraform" / "ignored.tftest.hcl"
+        )
 
         # Act
-        roots = find_module_test_roots(tmp_path)
+        roots = find_module_roots(tmp_path)
 
         # Assert
         assert roots == [
-            tmp_path / "modules" / "artifact_registry",
             tmp_path / "modules" / "service_accounts",
         ]
 
-    def test_finds_nested_module_tests(self, tmp_path: Path) -> None:
-        # Arrange
-        touch(tmp_path / "modules" / "service_accounts" / "tests" / "nested" / "test.tftest.hcl")
-
-        # Act
-        roots = find_module_test_roots(tmp_path)
-
-        # Assert
-        assert roots == [tmp_path / "modules" / "service_accounts"]
-
     def test_returns_empty_when_modules_missing(self, tmp_path: Path) -> None:
-        assert find_module_test_roots(tmp_path) == []
+        assert find_module_roots(tmp_path) == []

--- a/.github/scripts/tests/test_find_terraform_roots.py
+++ b/.github/scripts/tests/test_find_terraform_roots.py
@@ -42,10 +42,8 @@ class TestFindModuleRoots:
     def test_finds_module(self, tmp_path: Path) -> None:
         # Arrange
         touch(tmp_path / "modules" / "service_accounts" / "providers.tf")
-        touch(tmp_path / "modules" / "artifact_registry" / "basic.tftest.hcl")
-        touch(
-            tmp_path / "modules" / "data_platform" / ".terraform" / "ignored.tftest.hcl"
-        )
+        touch(tmp_path / "modules" / "artifact_registry" / "basic.tftest.hcl")  # providers.tf なし → 対象外
+        touch(tmp_path / "modules" / "data_platform" / ".terraform" / "providers.tf")  # .terraform 内 → 対象外
 
         # Act
         roots = find_module_roots(tmp_path)
@@ -53,6 +51,20 @@ class TestFindModuleRoots:
         # Assert
         assert roots == [
             tmp_path / "modules" / "service_accounts",
+        ]
+
+    def test_returns_sorted_multiple_modules(self, tmp_path: Path) -> None:
+        # Arrange
+        touch(tmp_path / "modules" / "z_module" / "providers.tf")
+        touch(tmp_path / "modules" / "a_module" / "providers.tf")
+
+        # Act
+        roots = find_module_roots(tmp_path)
+
+        # Assert
+        assert roots == [
+            tmp_path / "modules" / "a_module",
+            tmp_path / "modules" / "z_module",
         ]
 
     def test_returns_empty_when_modules_missing(self, tmp_path: Path) -> None:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -68,8 +68,8 @@ jobs:
     outputs:
       environment_roots: ${{ steps.find-roots.outputs.environment_roots }}
       environment_roots_count: ${{ steps.find-roots.outputs.environment_roots_count }}
-      module_test_roots: ${{ steps.find-roots.outputs.module_test_roots }}
-      module_test_roots_count: ${{ steps.find-roots.outputs.module_test_roots_count }}
+      module_roots: ${{ steps.find-roots.outputs.module_roots }}
+      module_roots_count: ${{ steps.find-roots.outputs.module_roots_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -101,15 +101,15 @@ jobs:
         with:
           working-directory: ${{ matrix.root }}
 
-  terraform-module-test:
-    name: terraform module test / ${{ matrix.root }}
+  terraform-module-ci:
+    name: terraform module ci / ${{ matrix.root }}
     needs: [terraform_fmt, find_terraform_roots]
-    if: ${{ needs.find_terraform_roots.outputs.module_test_roots_count != '0' }}
+    if: ${{ needs.find_terraform_roots.outputs.module_roots_count != '0' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        root: ${{ fromJson(needs.find_terraform_roots.outputs.module_test_roots) }}
+        root: ${{ fromJson(needs.find_terraform_roots.outputs.module_roots) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -118,7 +118,7 @@ jobs:
         uses: ./.github/actions/terraform-check
         with:
           working-directory: ${{ matrix.root }}
-          skip-validate: 'true'
+          skip-validate: "true"
 
   terraform-security-scan:
     name: Terraform security scan


### PR DESCRIPTION
## 概要
`find_terraform_roots.py` のモジュール検出ロジックを変更し、テストファイル (`*.tftest.hcl`) があるモジュールだけでなく、`providers.tf` を持つ全モジュールを CI（lint）対象にする。

## Why
terraform-ci の `terraform-module-ci` ジョブは validate をスキップし lint のみ実行する。テストの有無に関係なく全モジュールに lint をかけたいが、旧ロジックはテストファイルのあるモジュールしか対象にしていなかった。

## 関連 Issue
なし

## 変更内容
- `find_module_test_roots` を `find_module_roots` にリネームし、検出基準を `*.tftest.hcl` → `providers.tf` に変更
- 出力キーを `module_test_roots` / `module_test_roots_count` → `module_roots` / `module_roots_count` に統一（script・workflow両方）
- モジュールレベル docstring を新ロジックに合わせて更新
- テスト: `provider.tf` typo 修正（→ `providers.tf`）、クラス名 `TestFindModuleTestRoots` → `TestFindModuleRoots`、入れ子テストケース削除
- `action.yml` のクォートスタイルをダブルクォートに統一

## 影響範囲
- CI のみ。`terraform-module-ci` ジョブが、テストのないモジュールにも lint を実行するようになる
- 現在 `providers.tf` を持つモジュール: `google_project_services`, `service_accounts`, `artifact_registry`, `data_platform`, `tfstate_gcs_bucket`（5モジュール）

## 確認方法
- `PYTHONPATH=.github/scripts pytest .github/scripts/tests -v` → 4 passed

## レビュー観点
- `module_roots` というキー名が適切か
- `providers.tf` を module root のマーカーとして使う前提が全モジュールで成立しているか

## 補足
なし