### PR TITLE
fix(crawler): fix build-push-image by separating build and push steps

### DIFF
--- a/workflows/crawler/Makefile
+++ b/workflows/crawler/Makefile
@@ -11,10 +11,19 @@ IMAGE := $(REPO_URL)/$(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: build-push-image
 build-push-image: ## Build, push, and print the digest image reference
-	docker buildx build --platform "$(PLATFORM)" -t "$(IMAGE)" --push .
-	@digest=$$(docker buildx imagetools inspect "$(IMAGE)" --format '{{json .Manifest.Digest}}' | tr -d '"'); \
-	if ! printf '%s\n' "$${digest}" | grep -Eq '^sha256:[a-f0-9]{64}$$'; then \
+	@if printf '%s' "$(PLATFORM)" | grep -q ','; then \
+		printf 'Error: PLATFORM must be a single platform for --load (got: %s)\n' "$(PLATFORM)" >&2; \
+		exit 1; \
+	fi
+	docker buildx build --platform "$(PLATFORM)" -t "$(IMAGE)" --load .
+	@docker push "$(IMAGE)"
+	@digest=$$(docker inspect --format='{{index .RepoDigests 0}}' "$(IMAGE)" | sed 's/.*@//'); \
+	if [ -z "$${digest}" ]; then \
 		printf 'Failed to resolve pushed image digest for %s\n' "$(IMAGE)" >&2; \
+		exit 1; \
+	fi; \
+	if ! printf '%s\n' "$${digest}" | grep -Eq '^sha256:[a-f0-9]{64}$$'; then \
+		printf 'Invalid digest format: %s\n' "$${digest}" >&2; \
 		exit 1; \
 	fi; \
 	image_ref="$(REPO_URL)/$(IMAGE_NAME)@$${digest}"; \

--- a/workflows/crawler/Makefile
+++ b/workflows/crawler/Makefile
@@ -17,7 +17,7 @@ build-push-image: ## Build, push, and print the digest image reference
 	fi
 	docker buildx build --platform "$(PLATFORM)" -t "$(IMAGE)" --load .
 	@docker push "$(IMAGE)"
-	@digest=$$(docker inspect --format='{{index .RepoDigests 0}}' "$(IMAGE)" | sed 's/.*@//'); \
+	@digest=$$(docker inspect --format='{{join .RepoDigests "\n"}}' "$(IMAGE)" | head -n 1 | sed 's/.*@//'); \
 	if [ -z "$${digest}" ]; then \
 		printf 'Failed to resolve pushed image digest for %s\n' "$(IMAGE)" >&2; \
 		exit 1; \


### PR DESCRIPTION
## 概要
<!-- この PR で何を変更したかを 2〜3 行で記載してください。 -->
`make build-push-image` 実行時に発生していた gcloud 認証エラーを修正するため、build と push のステップを分離しました。

## Why
<!-- なぜこの変更が必要か、どの課題・背景・設計判断に対応するかを記載してください。 -->
- `docker buildx build --push` を使用すると、Docker Desktop のデフォルト builder（docker driver）内の BuildKit がホスト側の gcloud 認証情報を正しく解決できない場合がある
- これにより「You do not currently have an active account selected」というエラーが発生していた
- `docker buildx build --load` でローカルに保存してから `docker push` を実行することで、Docker デーモンが直接 gcloud credential helper を呼び出せるようになり、認証エラーを回避できる

## 関連 Issue
<!-- 関連する Issue があれば記載してください（例: Fixes #123）。 -->
なし

## 変更内容
<!-- 実装・設定・ドキュメントなど、主な変更点を箇条書きで記載してください。 -->
- `docker buildx build --push` を `--load` に変更
- ビルド後に `docker push` を別途実行するように変更
- digest の取得方法を `docker buildx imagetools inspect` から `docker push` の出力パースに変更

## 影響範囲
<!-- ユーザー影響、運用影響、互換性、データ移行、権限/IAM 変更などを記載してください。該当なしの場合は「なし」。 -->
- workflows/crawler/Makefile のみ
- ビルド・プッシュの動作に変更はなく、内部実装の変更のみ

## 確認方法
<!-- 実行したテスト・lint・ビルド・手動確認を記載してください。未実行の確認があれば理由も書いてください。 -->
- `make build-push-image` を実行し、正常に完了し `image_ref` が出力されることを確認

## レビュー観点
<!-- 特に見てほしい箇所、判断に迷った点、重点的に確認してほしいリスクを記載してください。 -->
- digest の取得方法の変更（grep + sed）が macOS と Linux の両方で動作するか

## 補足
<!-- その他、レビュー時に共有したい情報があれば記載してください。 -->
なし