### PR TITLE
chore(crawler): clarify DBLP fetch log context

### DIFF
--- a/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
+++ b/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
@@ -98,7 +98,7 @@ class CrawlConferencePapers:
         logger.info(f"Fetching {self.conf_name.upper()} {year} papers from DBLP...")
         papers = await self.paper_retriever.fetch_papers(conf=self.conf_name, year=year, h=1000)
         logger.info(
-            f"Fetched {len(papers)} papers from DBLP in {self.conf_name.upper()} conference"
+            f"Fetched {len(papers)} papers from DBLP for {self.conf_name.upper()} {year}"
         )
 
         # 2. DOI のない論文を除外 (これ以降の Enrich 処理で DOI が必要なため)

--- a/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
+++ b/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
@@ -97,7 +97,9 @@ class CrawlConferencePapers:
         # 1. 指定学会の論文一覧を取得
         logger.info(f"Fetching {self.conf_name.upper()} {year} papers from DBLP...")
         papers = await self.paper_retriever.fetch_papers(conf=self.conf_name, year=year, h=1000)
-        logger.info(f"Fetched {len(papers)} papers from DBLP")
+        logger.info(
+            f"Fetched {len(papers)} papers from DBLP in {self.conf_name.upper()} conference"
+        )
 
         # 2. DOI のない論文を除外 (これ以降の Enrich 処理で DOI が必要なため)
         papers = [p for p in papers if p.doi is not None]

--- a/workflows/crawler/tests/usecase/test_fetch_conference_papers.py
+++ b/workflows/crawler/tests/usecase/test_fetch_conference_papers.py
@@ -125,6 +125,31 @@ async def test_execute_flow(
 
 
 @pytest.mark.asyncio
+async def test_execute_logs_fetch_result_with_conference_and_year(
+    mock_dblp_repo: MagicMock,
+    mock_datalake: MagicMock,
+    mocker: MockerFixture,
+) -> None:
+    """DBLP取得後のログに学会名と年度の両方が含まれること"""
+    mock_dblp_repo.fetch_papers.return_value = [
+        Paper(title="P1", authors=[], year=2024, venue="RecSys", doi="10.1145/1"),
+    ]
+
+    mock_logger = mocker.patch("crawler.application.usecases.crawl_conference_papers.logger")
+
+    usecase = CrawlConferencePapers(
+        conf_name=ConferenceName.RECSYS,
+        paper_retriever=mock_dblp_repo,
+        paper_enrichers=[],
+        paper_datalake=mock_datalake,
+    )
+
+    await usecase.execute(2024)
+
+    mock_logger.info.assert_any_call("Fetched 1 papers from DBLP for RECSYS 2024")
+
+
+@pytest.mark.asyncio
 async def test_apply_enrichments_updates_all_papers_with_same_doi(
     mock_dblp_repo: MagicMock,
     mock_semantic_scholar_repo: MagicMock,


### PR DESCRIPTION
## 概要
DBLP から取得した論文数のログに、対象 conference 名を含めるようにしました。

## Why
クロール実行時のログだけで、どの conference に対する取得結果か判別しやすくするためです。

## 関連 Issue
なし

## 変更内容
- DBLP 取得後のログメッセージに `self.conf_name.upper()` を追加

## 影響範囲
ユーザー影響、互換性、データ移行、権限/IAM 変更はありません。ログ出力のみ変更されます。

## 確認方法
- `uv run pytest`（workflows/crawler）: 81 passed

## レビュー観点
ログ文言が運用上わかりやすいか確認してください。

## 補足
現在の差分についてコードレビューを実施済みで、指摘事項はありませんでした。