### PR TITLE
refactor(crawler): extract image push script

### DIFF
--- a/workflows/crawler/Makefile
+++ b/workflows/crawler/Makefile
@@ -11,20 +11,8 @@ IMAGE := $(REPO_URL)/$(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: build-push-image
 build-push-image: ## Build, push, and print the digest image reference
-	@if printf '%s' "$(PLATFORM)" | grep -q ','; then \
-		printf 'Error: PLATFORM must be a single platform for --load (got: %s)\n' "$(PLATFORM)" >&2; \
-		exit 1; \
-	fi
-	docker buildx build --platform "$(PLATFORM)" -t "$(IMAGE)" --load .
-	@docker push "$(IMAGE)"
-	@digest=$$(docker inspect --format='{{join .RepoDigests "\n"}}' "$(IMAGE)" | head -n 1 | sed 's/.*@//'); \
-	if [ -z "$${digest}" ]; then \
-		printf 'Failed to resolve pushed image digest for %s\n' "$(IMAGE)" >&2; \
-		exit 1; \
-	fi; \
-	if ! printf '%s\n' "$${digest}" | grep -Eq '^sha256:[a-f0-9]{64}$$'; then \
-		printf 'Invalid digest format: %s\n' "$${digest}" >&2; \
-		exit 1; \
-	fi; \
-	image_ref="$(REPO_URL)/$(IMAGE_NAME)@$${digest}"; \
-	printf 'image_ref: %s\n' "$${image_ref}"
+	@IMAGE_TAG="$(IMAGE_TAG)" \
+		REPO_URL="$(REPO_URL)" \
+		IMAGE_NAME="$(IMAGE_NAME)" \
+		PLATFORM="$(PLATFORM)" \
+		./scripts/build-push-image.sh

--- a/workflows/crawler/scripts/build-push-image.sh
+++ b/workflows/crawler/scripts/build-push-image.sh
@@ -12,6 +12,12 @@ REPO_URL="${REPO_URL:?REPO_URL is required}"
 IMAGE_NAME="${IMAGE_NAME:?IMAGE_NAME is required}"
 PLATFORM="${PLATFORM:?PLATFORM is required}"
 
+# Resolve the crawler directory relative to this script so the build context is
+# independent of the caller's current working directory. This lets the script be
+# reused from the Makefile, from repo root, or from GitHub Actions without
+# accidentally building the wrong context.
+CRAWLER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # The tag is convenient for building and pushing, but it is mutable. Terraform
 # should receive the digest-based reference printed at the end of this script.
 IMAGE="${REPO_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
@@ -25,7 +31,7 @@ fi
 
 # Build the image for the requested platform and load it into the local Docker
 # daemon so it can be pushed and inspected by the following steps.
-docker buildx build --platform "${PLATFORM}" -t "${IMAGE}" --load .
+docker buildx build --platform "${PLATFORM}" -t "${IMAGE}" --load "${CRAWLER_DIR}"
 
 # Push the mutable tag to Artifact Registry. The registry records the immutable
 # content digest, which we resolve from Docker metadata below.

--- a/workflows/crawler/scripts/build-push-image.sh
+++ b/workflows/crawler/scripts/build-push-image.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and push the crawler image, then print the immutable digest reference.
+#
+# This script is intentionally usable from both the Makefile and future
+# GitHub Actions workflows. Authentication is expected to be prepared by the
+# caller, for example with gcloud/docker login before invoking this script.
+
+IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
+REPO_URL="${REPO_URL:?REPO_URL is required}"
+IMAGE_NAME="${IMAGE_NAME:?IMAGE_NAME is required}"
+PLATFORM="${PLATFORM:?PLATFORM is required}"
+
+# The tag is convenient for building and pushing, but it is mutable. Terraform
+# should receive the digest-based reference printed at the end of this script.
+IMAGE="${REPO_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+# docker buildx --load can only load a single-platform image into the local
+# Docker daemon. Reject comma-separated platform lists before build starts.
+if [[ "${PLATFORM}" == *,* ]]; then
+  printf 'Error: PLATFORM must be a single platform for --load (got: %s)\n' "${PLATFORM}" >&2
+  exit 1
+fi
+
+# Build the image for the requested platform and load it into the local Docker
+# daemon so it can be pushed and inspected by the following steps.
+docker buildx build --platform "${PLATFORM}" -t "${IMAGE}" --load .
+
+# Push the mutable tag to Artifact Registry. The registry records the immutable
+# content digest, which we resolve from Docker metadata below.
+docker push "${IMAGE}"
+
+# Resolve the pushed digest from RepoDigests and strip the repository prefix so
+# only the sha256 digest remains, matching Terraform's expected image format.
+digest="$(docker inspect --format='{{join .RepoDigests "\n"}}' "${IMAGE}" | head -n 1 | sed 's/.*@//')"
+
+if [[ -z "${digest}" ]]; then
+  printf 'Failed to resolve pushed image digest for %s\n' "${IMAGE}" >&2
+  exit 1
+fi
+
+# Keep this validation aligned with Terraform's crawler_image validation, which
+# expects the final image reference to end with @sha256:<64 lowercase hex chars>.
+if ! [[ "${digest}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+  printf 'Invalid digest format: %s\n' "${digest}" >&2
+  exit 1
+fi
+
+image_ref="${REPO_URL}/${IMAGE_NAME}@${digest}"
+printf 'image_ref: %s\n' "${image_ref}"


### PR DESCRIPTION
## Summary
- Extract crawler Docker build/push/digest logic from `workflows/crawler/Makefile` into `workflows/crawler/scripts/build-push-image.sh`
- Keep `make build-push-image` as a compatibility wrapper that passes the existing variables to the script
- Add explanatory script comments for platform validation, mutable tag push, digest extraction, and digest output

## Test Plan
- [x] `bash -n workflows/crawler/scripts/build-push-image.sh`
- [x] `make -C workflows/crawler help`
- [x] `make -C workflows/crawler build-push-image PLATFORM='linux/amd64,linux/arm64'` fails before Docker build with expected validation error
- [x] `make -C workflows/crawler test` (82 passed)

Full image push was not run because it requires Docker, Artifact Registry authentication, and push permission.