### PR TITLE
feat(crawler): include year in GCS paper upload path

### DIFF
--- a/workflows/crawler/README.md
+++ b/workflows/crawler/README.md
@@ -256,7 +256,7 @@ arXiv APIから論文情報を取得する。
 
 論文データを JSONL 形式でバッチ分割して GCS にアップロードする。
 
-- ファイル名: `{papers_rep_name}_{timestamp}_{uuid}.jsonl`
+- 保存パス: `{prefix_path}/{conference}/{year}/{conference}_{timestamp}_{uuid}.jsonl`
 - デフォルトバッチサイズ: 100件
 - 並列アップロード数: 最大5
 

--- a/workflows/crawler/README.md
+++ b/workflows/crawler/README.md
@@ -256,7 +256,7 @@ arXiv APIから論文情報を取得する。
 
 論文データを JSONL 形式でバッチ分割して GCS にアップロードする。
 
-- 保存パス: `{prefix_path}/{conference}/{year}/{conference}_{timestamp}_{uuid}.jsonl`
+- 保存パス: `{prefix_path}/{conference}/{year}/{conference}_{timestamp}_{uuid_suffix}.jsonl`
 - デフォルトバッチサイズ: 100件
 - 並列アップロード数: 最大5
 

--- a/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
+++ b/workflows/crawler/src/crawler/application/usecases/crawl_conference_papers.py
@@ -97,9 +97,7 @@ class CrawlConferencePapers:
         # 1. 指定学会の論文一覧を取得
         logger.info(f"Fetching {self.conf_name.upper()} {year} papers from DBLP...")
         papers = await self.paper_retriever.fetch_papers(conf=self.conf_name, year=year, h=1000)
-        logger.info(
-            f"Fetched {len(papers)} papers from DBLP for {self.conf_name.upper()} {year}"
-        )
+        logger.info(f"Fetched {len(papers)} papers from DBLP for {self.conf_name.upper()} {year}")
 
         # 2. DOI のない論文を除外 (これ以降の Enrich 処理で DOI が必要なため)
         papers = [p for p in papers if p.doi is not None]
@@ -126,7 +124,7 @@ class CrawlConferencePapers:
         # 4. 補完された論文をデータレイクに保存
         logger.info(f"Saving enriched {self.conf_name.upper()} {year} papers to datalake...")
         save_results = await self.paper_datalake.save_papers(
-            papers, papers_rep_name=self.conf_name.value
+            papers, papers_rep_name=self.conf_name.value, year=year
         )
         logger.info(f"Saved {len([r for r in save_results if r.success])} batches successfully.")
 

--- a/workflows/crawler/src/crawler/domain/repositories/repository.py
+++ b/workflows/crawler/src/crawler/domain/repositories/repository.py
@@ -81,12 +81,15 @@ class PaperDatalake(Protocol):
     論文データをバッチ分割し、外部ストレージに永続化するインターフェースを定義します。
     """
 
-    async def save_papers(self, papers: list[Paper], papers_rep_name: str) -> list[SaveResult]:
+    async def save_papers(
+        self, papers: list[Paper], papers_rep_name: str, year: int
+    ) -> list[SaveResult]:
         """論文データをストレージに保存します。
 
         Args:
             papers: 保存対象の論文オブジェクトのリスト。
             papers_rep_name: ファイル名のプレフィックスに使用するリポジトリ名。
+            year: 保存先パスに含める対象年度。
 
         Returns:
             各バッチの保存結果を表す SaveResult オブジェクトのリスト。

--- a/workflows/crawler/src/crawler/infrastructure/http/http_utils.py
+++ b/workflows/crawler/src/crawler/infrastructure/http/http_utils.py
@@ -86,6 +86,7 @@ def make_wait_retry_after(retry_statuses: frozenset[int]) -> Callable[[RetryCall
     対象ステータスかつ Retry-After ヘッダーがあればその値を使い、
     なければ指数バックオフにフォールバックする。
     """
+
     def wait_retry_after(retry_state: RetryCallState) -> float:
         if retry_state.outcome is not None and retry_state.outcome.exception() is None:
             result = retry_state.outcome.result()

--- a/workflows/crawler/src/crawler/infrastructure/repositories/gcs_datalake.py
+++ b/workflows/crawler/src/crawler/infrastructure/repositories/gcs_datalake.py
@@ -58,7 +58,9 @@ class GCSDatalake:
         self.batch_size = batch_size
         self.semaphore = asyncio.Semaphore(self.DEFAULT_CONCURRENCY)
 
-    async def save_papers(self, papers: list[Paper], papers_rep_name: str) -> list[SaveResult]:
+    async def save_papers(
+        self, papers: list[Paper], papers_rep_name: str, year: int
+    ) -> list[SaveResult]:
         """論文データをバッチ分割して GCS に並列保存します。
 
         入力された論文リストを ``batch_size`` 単位で分割し、各バッチを
@@ -70,6 +72,8 @@ class GCSDatalake:
             papers_rep_name: ファイル名のプレフィックスに使用するリポジトリ名。
                 例: "recsys", "nips", "arxiv"。ファイル名は
                 ``{papers_rep_name}_{timestamp}_{uuid_suffix}.jsonl`` となります。
+            year: 保存先パスに含める対象年度。GCS オブジェクトキーは
+                ``{prefix_path}/{papers_rep_name}/{year}/{fname}`` となります。
 
         Returns:
             各バッチの保存結果を表す SaveResult オブジェクトのリスト。
@@ -85,11 +89,8 @@ class GCSDatalake:
                 timestamp = now.strftime("%Y%m%d_%H%M%S_%f")
                 uuid_suffix = uuid.uuid4().hex[:8]  # UUIDの先頭8文字を使用
                 fname = f"{papers_rep_name}_{timestamp}_{uuid_suffix}.jsonl"
-                tasks.append(
-                    tg.create_task(
-                        self._save_content(self.bucket.blob(f"{self.prefix_path}/{fname}"), data)
-                    )
-                )
+                blob_name = f"{self.prefix_path}/{papers_rep_name}/{year}/{fname}"
+                tasks.append(tg.create_task(self._save_content(self.bucket.blob(blob_name), data)))
         results = [task.result() for task in tasks]
         failed_batches = [res for res in results if not res.success]
         if failed_batches:

--- a/workflows/crawler/src/crawler/infrastructure/repositories/gcs_datalake.py
+++ b/workflows/crawler/src/crawler/infrastructure/repositories/gcs_datalake.py
@@ -6,6 +6,7 @@
 """
 
 import asyncio
+import posixpath
 import uuid
 from datetime import datetime, timezone
 
@@ -89,7 +90,7 @@ class GCSDatalake:
                 timestamp = now.strftime("%Y%m%d_%H%M%S_%f")
                 uuid_suffix = uuid.uuid4().hex[:8]  # UUIDの先頭8文字を使用
                 fname = f"{papers_rep_name}_{timestamp}_{uuid_suffix}.jsonl"
-                blob_name = f"{self.prefix_path}/{papers_rep_name}/{year}/{fname}"
+                blob_name = posixpath.join(self.prefix_path, papers_rep_name, str(year), fname)
                 tasks.append(tg.create_task(self._save_content(self.bucket.blob(blob_name), data)))
         results = [task.result() for task in tasks]
         failed_batches = [res for res in results if not res.success]

--- a/workflows/crawler/tests/repository/test_gcs_datalake.py
+++ b/workflows/crawler/tests/repository/test_gcs_datalake.py
@@ -72,12 +72,12 @@ async def test_save_papers(
     )
 
     # save_papersを呼び出す
-    results = await datalake.save_papers(papers, papers_rep_name="test")
+    results = await datalake.save_papers(papers, papers_rep_name="test", year=2025)
 
     # バケットとblobの呼び出しを検証
     # ファイル名には timestamp と UUID が含まれるため正規表現で検証する
-    # 形式: papers/test_{YYYYMMDD}_{HHMMSS}_{microseconds}_{uuid8}.jsonl
-    blob_name_pattern = re.compile(r"papers/test_\d{8}_\d{6}_\d{6}_[a-f0-9]{8}\.jsonl")
+    # 形式: papers/test/2025/test_{YYYYMMDD}_{HHMMSS}_{microseconds}_{uuid8}.jsonl
+    blob_name_pattern = re.compile(r"papers/test/2025/test_\d{8}_\d{6}_\d{6}_[a-f0-9]{8}\.jsonl")
     actual_blob_calls = [c.args[0] for c in mock_bucket.blob.call_args_list]
     assert len(actual_blob_calls) == 2  # batch_size=1 なので 2バッチ
     for blob_path in actual_blob_calls:

--- a/workflows/crawler/tests/usecase/test_fetch_conference_papers.py
+++ b/workflows/crawler/tests/usecase/test_fetch_conference_papers.py
@@ -117,6 +117,7 @@ async def test_execute_flow(
     mock_datalake.save_papers.assert_called_once_with(
         [initial_papers[0]],
         papers_rep_name="recsys",
+        year=year,
     )
 
     assert result == [initial_papers[0]]


### PR DESCRIPTION
## Summary
- Include the conference year in the crawler GCS upload path.
- New path format: `papers/<conference>/<year>/<conference>_<timestamp>_<uuid>.jsonl`
- Updated `PaperDatalake.save_papers` signature and all call sites, tests, and README.

## Test Plan
- `make -C workflows/crawler fmt`: passed
- `make -C workflows/crawler lint`: passed
- `make -C workflows/crawler test`: passed (82/82)