### PR TITLE
refactor(ci): use external script in find_target_projects action

### DIFF
--- a/.github/actions/find_target_projects/action.yaml
+++ b/.github/actions/find_target_projects/action.yaml
@@ -34,43 +34,14 @@ runs:
     - name: Find Target Projects
       uses: actions/github-script@v7
       id: find-target-projects
+      env:
+        TARGET_PROJECTS: ${{ inputs.target_projects }}
+        REQUIRED_FILES: ${{ inputs.required_files }}
+        CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
       with:
         script: |
-          const fs = require('node:fs');
-          // If target_projects input is provided, use it
-          let dispatch_inputs = "${{ inputs.target_projects }}";
-          if (dispatch_inputs !== "") {
-            dispatch_inputs = dispatch_inputs.split(',').map(path => path.trim());
-            core.setOutput('projects', JSON.stringify(dispatch_inputs));
-          } else { // If no input is provided, get directories from changed files
-            const changed_paths = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
-            // convert ['hoge/fuga', 'foo/zoo'] => ['hoge', 'hoge/fuga', 'foo', 'foo/zoo']
-            const set = new Set();
-            changed_paths.forEach(path => {
-              const segments = path.split('/');
-              let current = '';
-              segments.forEach((segment, index) => {
-                current = index === 0 ? segment : `${current}/${segment}`;
-                set.add(current);
-              });
-            });
-            const changed_directories = Array.from(set);
-            const required_files = "${{ inputs.required_files }}".split(',').map(path => path.trim());
-            // Filter out directories that contain required files.
-            const projects = changed_directories.filter(path => {
-              if (
-                fs.existsSync(path) && fs.statSync(path).isDirectory()
-              ) {
-                // Check if all required files exist in the directory
-                const all_files_exist = required_files.every(file => fs.existsSync(`${path}/${file}`));
-                if (all_files_exist) {
-                  return true;
-                }
-              }
-              return false;
-            });
-            core.setOutput('projects', JSON.stringify(projects));
-          }
+          const script = require('${{ github.action_path }}/../../scripts/find_target_project.js');
+          await script({ github, context, core });
     - name: Print changed directories
       run: |
         echo "::debug::Found Projects: ${{ steps.find-target-projects.outputs.projects }}"

--- a/.github/scripts/find_target_project.js
+++ b/.github/scripts/find_target_project.js
@@ -18,7 +18,10 @@ module.exports = async ({ core }) => {
   // If target_projects input is provided, use it as-is.
   const dispatchInput = (process.env.TARGET_PROJECTS ?? '').trim();
   if (dispatchInput !== '') {
-    const projects = dispatchInput.split(',').map(path => path.trim());
+    const projects = dispatchInput
+      .split(',')
+      .map(path => path.trim())
+      .filter(Boolean);
     core.setOutput('projects', JSON.stringify(projects));
     return;
   }
@@ -40,7 +43,13 @@ module.exports = async ({ core }) => {
 
   const requiredFiles = (process.env.REQUIRED_FILES ?? '')
     .split(',')
-    .map(path => path.trim());
+    .map(path => path.trim())
+    .filter(Boolean);
+
+  if (requiredFiles.length === 0) {
+    core.setFailed('REQUIRED_FILES must not be empty');
+    return;
+  }
 
   // Keep only directories that contain all required files.
   const projects = changedDirectories.filter(path => {

--- a/.github/scripts/find_target_project.js
+++ b/.github/scripts/find_target_project.js
@@ -1,58 +1,53 @@
-// .github/scripts/release-helper.js
+// .github/scripts/find_target_project.js
 
 /**
+ * Find target projects from changed files (or explicit input).
+ *
+ * Inputs are passed via environment variables so this module can be loaded by
+ * actions/github-script with `require`:
+ *   - TARGET_PROJECTS: comma separated project paths. If set, used as-is.
+ *   - REQUIRED_FILES:  comma separated file names that identify a project.
+ *   - CHANGED_FILES:   JSON array of changed file/directory paths.
+ *
  * @param {object} params
- * @param {import('@octokit/rest').Octokit} params.github
- * @param {import('@actions/github/lib/context').Context} params.context
  * @param {import('@actions/core')} params.core
  */
-module.exports = async ({ github, context, core }) => {
-  // ここにロジックを書く
-  core.info("外部スクリプトを開始します");
+module.exports = async ({ core }) => {
   const fs = require('node:fs');
-  // If target_projects input is provided, use it
-  let dispatch_inputs = "${{ inputs.target_projects }}";
-  if (dispatch_inputs !== "") {
-    dispatch_inputs = dispatch_inputs.split(',').map(path => path.trim());
-    core.setOutput('projects', JSON.stringify(dispatch_inputs));
-  } else { // If no input is provided, get directories from changed files
-    const changed_paths = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
-    // convert ['hoge/fuga', 'foo/zoo'] => ['hoge', 'hoge/fuga', 'foo', 'foo/zoo']
-    const set = new Set();
-    changed_paths.forEach(path => {
-      const segments = path.split('/');
-      let current = '';
-      segments.forEach((segment, index) => {
-        current = index === 0 ? segment : `${current}/${segment}`;
-        set.add(current);
-      });
-    });
-    const changed_directories = Array.from(set);
-    const required_files = "${{ inputs.required_files }}".split(',').map(path => path.trim());
-    // Filter out directories that contain required files.
-    const projects = changed_directories.filter(path => {
-      if (
-        fs.statSync(path).isDirectory()
-      ) {
-        // Check if all required files exist in the directory
-        const all_files_exist = required_files.every(file => fs.existsSync(`${path}/${file}`));
-        if (all_files_exist) {
-          return true;
-        }
-      }
-      return false;
-    });
+
+  // If target_projects input is provided, use it as-is.
+  const dispatchInput = (process.env.TARGET_PROJECTS ?? '').trim();
+  if (dispatchInput !== '') {
+    const projects = dispatchInput.split(',').map(path => path.trim());
     core.setOutput('projects', JSON.stringify(projects));
+    return;
   }
-  const { owner, repo } = context.repo;
 
-  // 例: Issueを作成する
-  await github.rest.issues.create({
-    owner,
-    repo,
-    title: "Automated Issue via Script",
-    body: "これは外部ファイルから作成されました。",
+  // Otherwise, derive projects from the changed files.
+  // CHANGED_FILES may be an empty string when nothing changed, so guard JSON.parse.
+  const changedPaths = JSON.parse((process.env.CHANGED_FILES ?? '').trim() || '[]');
+  // convert ['hoge/fuga', 'foo/zoo'] => ['hoge', 'hoge/fuga', 'foo', 'foo/zoo']
+  const set = new Set();
+  changedPaths.forEach(path => {
+    const segments = path.split('/');
+    let current = '';
+    segments.forEach((segment, index) => {
+      current = index === 0 ? segment : `${current}/${segment}`;
+      set.add(current);
+    });
   });
+  const changedDirectories = Array.from(set);
 
-  return "完了";
+  const requiredFiles = (process.env.REQUIRED_FILES ?? '')
+    .split(',')
+    .map(path => path.trim());
+
+  // Keep only directories that contain all required files.
+  const projects = changedDirectories.filter(path => {
+    if (fs.existsSync(path) && fs.statSync(path).isDirectory()) {
+      return requiredFiles.every(file => fs.existsSync(`${path}/${file}`));
+    }
+    return false;
+  });
+  core.setOutput('projects', JSON.stringify(projects));
 };


### PR DESCRIPTION
## 概要
`find_target_projects` composite action のインライン `github-script` を廃止し、`.github/scripts/find_target_project.js` を `require` して呼び出すように変更した。ロジックの重複を解消し、CI 用スクリプトを単一の正本として保守できるようにする。

## Why
`.github/scripts/find_target_project.js` が定義されていたが、`.github/actions/find_target_projects` ではインラインスクリプトが使われており、同一ロジックが二重管理になっていた。加えて、外部スクリプト側は GitHub Actions テンプレート構文（`${{ ... }}`）がそのまま埋め込まれており、`require` しても動作しない状態だった。

## 関連 Issue
なし

## 変更内容
- `action.yaml` のインライン `github-script` を削除し、外部スクリプトを `require` して実行する形に変更
- `find_target_project.js` を環境変数（`TARGET_PROJECTS` / `REQUIRED_FILES` / `CHANGED_FILES`）経由で入力を受け取る Node モジュールとして書き直し
- 無関係だった Issue 作成ボイラープレートを削除
- 空の `CHANGED_FILES` に対する `JSON.parse` ガードを追加
- `fs.existsSync(path)` ガードを追加し、存在しないパスでの `statSync` 例外を防止
- レビュー指摘対応: `TARGET_PROJECTS` / `REQUIRED_FILES` のカンマ分割後に空要素を `.filter(Boolean)` で除外
- レビュー指摘対応: `REQUIRED_FILES` が空配列になった場合は `core.setFailed` で失敗させ、`every()` の vacuous truth による誤判定を防止

## 影響範囲
- `python-ci` ワークフローの `find_target_projects` ジョブのみ
- 出力形式（`projects` の JSON 配列）は変更なし
- ユーザー影響・データ移行・権限/IAM 変更: なし

## 確認方法
- [x] `node --check .github/scripts/find_target_project.js` で構文チェック
- [x] 環境変数を与えたローカル実行で `target_projects` 指定時のパススルーと、変更ファイルからの抽出（空入力時 `[]`）を確認
- [x] `TARGET_PROJECTS="a/b, c/d,"` で空要素が除外されることを確認
- [x] `REQUIRED_FILES=","` で `core.setFailed` されることを確認
- [x] `python-ci` ワークフローで PR トリガー時に `find_target_projects` ジョブが成功すること
- [x] 変更ファイルに応じて `projects` 出力が正しく生成されること（本 PR は `.github/**` のみ変更のため `projects=[]`、`Lint and Test` は skip が期待どおり）
- [ ] `workflow_dispatch` で `target_projects` を指定した場合、その値がそのまま使われること（手動確認待ち）

## レビュー観点
- `${{ github.action_path }}/../../scripts/find_target_project.js` のパス解決が composite action 内で正しいか
- 環境変数の受け渡し（`action.yaml` の `env:` ↔ スクリプトの `process.env`）が一致しているか
- P0 指摘（空要素フィルタ、`requiredFiles` 空配列時の失敗）への対応

## 補足
P1 指摘（Windows ランナー向け `ACTION_PATH` env + `path.resolve`）は未対応。現状 `python-ci` は `ubuntu-latest` のみのため別途対応可能。