### PR TITLE
feat(terraform): Cursor OIDC WIF を direct resource access で定義する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 
 現在、以下のドメインの ADR が存在します。
 
-- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（9件）
+- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（13件）
 - **crawler/**: クローラーの実装言語、XML パース戦略など（2件）
 
 各ドメインの詳細な一覧と運用ルールについては、[adr/README.md](adr/README.md) を参照してください。

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 
 現在、以下のドメインの ADR が存在します。
 
-- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（13件）
+- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（14件）
 - **crawler/**: クローラーの実装言語、XML パース戦略など（2件）
 
 各ドメインの詳細な一覧と運用ルールについては、[adr/README.md](adr/README.md) を参照してください。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,8 @@
 | `INFRA-ADR-010` | `infra` | Cloud Run Job の管理責務を Terraform に集約する | Accepted | [docs/adr/infra/010-cloud-run-job-management.md](infra/010-cloud-run-job-management.md) |
 | `INFRA-ADR-011` | `infra` | Terraform monorepo における CI 対象検出と検証方針 | Accepted | [docs/adr/infra/011-terraform-ci-for-monorepo.md](infra/011-terraform-ci-for-monorepo.md) |
 | `INFRA-ADR-012` | `infra` | Cloud Run Job の実行粒度と実行時パラメータ設計 | Accepted | [docs/adr/infra/012-crawler-execution-parameters.md](infra/012-crawler-execution-parameters.md) |
-| `INFRA-ADR-013` | `infra` | Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用する | Accepted | [docs/adr/infra/013-cursor-oidc-workload-identity-federation.md](infra/013-cursor-oidc-workload-identity-federation.md) |
+| `INFRA-ADR-013` | `infra` | Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用する | Superseded | [docs/adr/infra/013-cursor-oidc-workload-identity-federation.md](infra/013-cursor-oidc-workload-identity-federation.md) |
+| `INFRA-ADR-014` | `infra` | Cursor Cloud の GCP 権限は WIF federated principal への direct resource access とする | Accepted | [docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md](infra/014-cursor-oidc-wif-direct-resource-access.md) |
 | `CRAWLER-ADR-001` | `crawler` | 論文収集クローラーの実装言語としてPythonを採用 | Accepted | [docs/adr/crawler/001-language-selection.md](crawler/001-language-selection.md) |
 | `CRAWLER-ADR-002` | `crawler` | XMLパースにdefusedxmlを採用 | Accepted | [docs/adr/crawler/002-xml-parsing-security.md](crawler/002-xml-parsing-security.md) |
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@
 | `INFRA-ADR-010` | `infra` | Cloud Run Job の管理責務を Terraform に集約する | Accepted | [docs/adr/infra/010-cloud-run-job-management.md](infra/010-cloud-run-job-management.md) |
 | `INFRA-ADR-011` | `infra` | Terraform monorepo における CI 対象検出と検証方針 | Accepted | [docs/adr/infra/011-terraform-ci-for-monorepo.md](infra/011-terraform-ci-for-monorepo.md) |
 | `INFRA-ADR-012` | `infra` | Cloud Run Job の実行粒度と実行時パラメータ設計 | Accepted | [docs/adr/infra/012-crawler-execution-parameters.md](infra/012-crawler-execution-parameters.md) |
+| `INFRA-ADR-013` | `infra` | Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用する | Accepted | [docs/adr/infra/013-cursor-oidc-workload-identity-federation.md](infra/013-cursor-oidc-workload-identity-federation.md) |
 | `CRAWLER-ADR-001` | `crawler` | 論文収集クローラーの実装言語としてPythonを採用 | Accepted | [docs/adr/crawler/001-language-selection.md](crawler/001-language-selection.md) |
 | `CRAWLER-ADR-002` | `crawler` | XMLパースにdefusedxmlを採用 | Accepted | [docs/adr/crawler/002-xml-parsing-security.md](crawler/002-xml-parsing-security.md) |
 

--- a/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
+++ b/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
@@ -131,6 +131,80 @@ ops に Cursor 用 WIF pool を置き、app-dev の `cursor-cloud` を短命 imp
 
 Cursor Cloud Agent から GCP への認証は、Cursor OIDC と GCP WIF による短命 impersonation とする。借りる identity は `cursor-cloud@haru256-devgist-app-dev.iam.gserviceaccount.com` である。
 
+### 認証の流れ
+
+WIF は、外部 IdP が出した JWT を GCP が検証し、短命トークンに交換する仕組みである。JSON キーは無く、交換のたびに Cursor の署名と ops 上の provider 条件を見る。
+
+役割の配置は次の通りである。
+
+```mermaid
+flowchart LR
+  subgraph cursorSide [Cursor Cloud]
+    Agent[Cloud Agent VM]
+    Socket[OIDC socket]
+    Agent --> Socket
+  end
+
+  subgraph opsProject [haru256-devgist-ops]
+    Pool[WIF pool cursor]
+    Provider[OIDC provider oidc]
+    Pool --> Provider
+  end
+
+  subgraph appProject [haru256-devgist-app-dev]
+    SA["SA cursor-cloud"]
+  end
+
+  subgraph dataProject [haru256-devgist-data-dev]
+    GCS[datalake bucket]
+  end
+
+  Socket -->|"JWT 5 min"| Sts[GCP STS]
+  Sts --> Provider
+  Provider -->|"federated token"| SA
+  SA --> GCS
+```
+
+実行時は mint、交換、impersonate、アクセスの順に進む。
+
+1. Cloud Agent が VM 内の Unix socket へ、WIF provider の既定 audience を付けて JWT を要求する。
+2. Cursor が RS256 で署名した JWT を返す。`iss` は `https://api.cursor.com`、寿命は 5 分、`sub` は Cursor ユーザーの安定 ID である。
+3. GCP STS が Cursor の JWKS で署名を検証し、ops の OIDC provider に照らして `aud`、`repo_url`、`agent_runtime` を確認する。
+4. 条件を満たせば federated token を出す。`google.subject` は JWT の `sub` になる。
+5. その `sub` が allowlist にあるときだけ、`cursor-cloud` を impersonate できる。
+6. GCS への読書きは、この SA に付いた IAM で決まる。JWT 自体に GCS 権限は無い。
+
+```mermaid
+sequenceDiagram
+  participant Agent as CloudAgent
+  participant Socket as CursorOIDC
+  participant Sts as GCP_STS
+  participant Jwks as CursorJWKS
+  participant Provider as WIF_provider
+  participant Sa as cursor_cloud_SA
+  participant Gcs as datalake
+
+  Agent->>Socket: mint JWT with provider audience
+  Socket-->>Agent: RS256 JWT
+  Note over Agent,Socket: iss api.cursor.com, sub user id, 5 min
+  Agent->>Sts: exchange JWT
+  Sts->>Jwks: verify signature
+  Sts->>Provider: check aud, repo_url, agent_runtime
+  alt audience or condition mismatch
+    Provider-->>Agent: reject
+  else JWT accepted
+    Sts-->>Agent: federated token
+    alt sub not allowlisted
+      Sa-->>Agent: impersonation denied
+    else sub allowlisted
+      Agent->>Sa: impersonate cursor-cloud
+      Sa->>Gcs: objectViewer and objectCreator
+    end
+  end
+```
+
+GitHub Actions 用 WIF はこの図に出てこない。CI の terraform apply は別 issuer、別信頼条件で組む。
+
 ### 採用方針
 
 - Cursor Cloud に SA JSON キーもユーザー ADC も置かない

--- a/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
+++ b/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
@@ -2,7 +2,7 @@
 
 ## Conclusion (結論)
 
-- Cursor Cloud Agent が GCP を操作するときは、Cursor が発行する短命 OIDC JWT を GCP Workload Identity Federation（WIF）で交換し、dev 用 Service Account `cursor-cloud` を impersonate する。
+- Cursor Cloud Agent が GCP を操作するときは、Cursor が発行する短命 OIDC JWT を GCP Workload Identity Federation（WIF）で交換し、Ops Project の Service Account `cursor-cloud` を impersonate する。
 - Service Account JSON キーと、人間ユーザーの Application Default Credentials を Cursor 環境に置かない。
 - 初期権限は `haru256-devgist-data-dev` の datalake に対する `roles/storage.objectViewer` と `roles/storage.objectCreator` に限定する。terraform apply や Cloud Run Job 起動はこの identity に含めない。
 - terraform apply は GitHub Actions 側の別 WIF で行う。Cursor Cloud 用 WIF と混ぜない。
@@ -51,8 +51,9 @@ AWS には `CURSOR_AWS_ASSUME_IAM_ROLE_ARN` という Cursor 公式の role assu
    - Cursor Cloud 用 WIF と GitHub Actions 用 WIF は別物にする
 
 5. **既存の project / state 分割を崩さない**
-   - WIF pool は ops、dev 用の操作 identity は app-dev
-   - apply 順 `ops -> app` を維持し、remote state の循環を作らない
+   - WIF pool と `cursor-cloud` SA は ops に置く。`github-actions` と同じ actor の置き方である
+   - 個別リソースへの IAM は、そのリソースを既に扱っている root に置く。ops に全 project の IAM を集めない
+   - apply 順 `ops -> app` を維持し、remote state の循環を作らない。ops が data の remote state に依存しない
 
 6. **信頼する Cursor 実行を絞る**
    - このリポジトリの managed Cloud Agent であること
@@ -75,7 +76,14 @@ AWS には `CURSOR_AWS_ASSUME_IAM_ROLE_ARN` という Cursor 公式の role assu
 |---|---|---|---|---|
 | Option A: Cloud Run の `crawler` SA を impersonate | agent と runtime を完全に同じ権限にしたい場合 | SA が増えない。本番パスと一致する | agent 侵害が crawler runtime と同じになる | 非採用 |
 | Option B: WIF の federated principal に直接 IAM を付ける | SA を増やしたくない場合 | impersonation が無い | 監査ログ上の principal が Cursor `sub` になり、既存の SA 運用と揃わない。権限追加のたびに principal 文字列を扱う | 非採用 |
-| Option C: dev 用の専用 SA `cursor-cloud` を impersonate | agent 用 identity を runtime から分け、後から権限を足したい場合 | blast radius を分けられる。名前が crawler に固定されない。監査は SA 単位 | SA が 1 つ増える。最初は datalake 以外何もできない | 採用 |
+| Option C: 専用 SA `cursor-cloud` を impersonate | agent 用 identity を runtime から分け、後から権限を足したい場合 | blast radius を分けられる。名前が crawler に固定されない。監査は SA 単位 | SA が 1 つ増える。最初は datalake 以外何もできない | 採用 |
+
+#### SA を置く project
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: `haru256-devgist-app-dev` | 権限が app-dev / data-dev に閉じる場合 | email に環境が表れる。crawler SA と同じ置き方 | project をまたぐ権限を足すたびに、identity が app-dev 所属のまま他 project を触ることになる。WIF と SA が state をまたぐ | 非採用 |
+| Option B: `haru256-devgist-ops` | 複数 project のリソースへ、後から IAM を足す actor | WIF pool、SA、impersonation allowlist が同じ project に揃う。`github-actions` と同じ actor 配置。INFRA-ADR-004 の「WIF と共通 SA は ops」と揃う | ops の project ID は環境を表さない。prod 権限を足す事故を、命名だけでは防げない | 採用 |
 
 #### 信頼する Cursor 実行
 
@@ -92,6 +100,7 @@ AWS には `CURSOR_AWS_ASSUME_IAM_ROLE_ARN` という Cursor 公式の role assu
 - 今の datalake 検証と、後の dev 開発用途を同じ identity で扱えること
 - terraform apply の実行主体を GitHub Actions に残すこと
 - 既存の ops / app-dev / data-dev 分割と apply 順を崩さないこと
+- 後から複数 project へ IAM を足せる actor 配置にすること
 
 ## Considered Options
 
@@ -118,7 +127,7 @@ WIF の先を既存の `crawler@haru256-devgist-app-dev.iam.gserviceaccount.com`
 
 ### Option C: Cursor OIDC + WIF で `cursor-cloud` を impersonate する [採用]
 
-ops に Cursor 用 WIF pool を置き、app-dev の `cursor-cloud` を短命 impersonate する。最初の IAM は datalake の読書きだけにする。
+ops に Cursor 用 WIF pool と `cursor-cloud` SA を置き、短命 impersonate する。最初のリソース IAM は data-dev datalake の読書きだけにする。
 
 採用理由:
 
@@ -129,7 +138,7 @@ ops に Cursor 用 WIF pool を置き、app-dev の `cursor-cloud` を短命 imp
 
 ## Decision (決定事項)
 
-Cursor Cloud Agent から GCP への認証は、Cursor OIDC と GCP WIF による短命 impersonation とする。借りる identity は `cursor-cloud@haru256-devgist-app-dev.iam.gserviceaccount.com` である。
+Cursor Cloud Agent から GCP への認証は、Cursor OIDC と GCP WIF による短命 impersonation とする。借りる identity は `cursor-cloud@haru256-devgist-ops.iam.gserviceaccount.com` である。
 
 ### 認証の流れ
 
@@ -148,11 +157,8 @@ flowchart LR
   subgraph opsProject [haru256-devgist-ops]
     Pool[WIF pool cursor]
     Provider[OIDC provider oidc]
-    Pool --> Provider
-  end
-
-  subgraph appProject [haru256-devgist-app-dev]
     SA["SA cursor-cloud"]
+    Pool --> Provider
   end
 
   subgraph dataProject [haru256-devgist-data-dev]
@@ -211,9 +217,10 @@ GitHub Actions 用 WIF はこの図に出てこない。CI の terraform apply �
 - Cloud Agent は Unix socket から OIDC JWT を mint し、GCP STS に渡す
 - JWT の `aud` は WIF provider の既定 audience（canonical resource URL）に固定する。汎用の `https://iam.googleapis.com` は使わない
 - issuer は `https://api.cursor.com`。JWKS は Cursor の discovery を使う
-- WIF pool と OIDC provider は `haru256-devgist-ops` に置く
-- impersonate 先 SA は `haru256-devgist-app-dev` の `cursor-cloud` とする。ops の `github-actions` とは別 actor である
-- `cursor-cloud` は runtime SA ではない。INFRA-ADR-008 の actor 名として `github-actions` と同じ置き方をする。環境は project ID の `app-dev` で表す
+- WIF pool、OIDC provider、impersonate 先 SA はすべて `haru256-devgist-ops` に置く。email は `cursor-cloud@haru256-devgist-ops.iam.gserviceaccount.com` である
+- `cursor-cloud` は runtime SA ではない。INFRA-ADR-008 の actor 名として `github-actions` と同じ project に置く。ops の project ID は環境を表さないので、権限の環境境界は IAM binding で守る。初期は data-dev のみである
+- `github-actions` と `cursor-cloud` は同じ ops に置くが、別 actor である。terraform apply 用 WIF には相乗りしない
+- リソースへの IAM は ops に集めない。INFRA-ADR-009 の platform / CI identity として、そのリソースを既に扱っている root が member に `cursor-cloud` を足す。初期の datalake 読書きは、crawler と同じく app-dev state が付与する。app-dev は ops と data の remote state を既に読むので、ops に data 依存を足さない
 - provider の attribute condition で、少なくとも次を要求する
   - `assertion.repo_url == "github.com/haru-256/devgist"`
   - `assertion.agent_runtime == "managed"`
@@ -227,18 +234,18 @@ GitHub Actions 用 WIF はこの図に出てこない。CI の terraform apply �
 
 ```
 haru256-devgist-ops
-└── WIF
-    ├── pool: cursor
-    └── provider: oidc
-        ├── issuer: https://api.cursor.com
-        └── condition: repo_url と agent_runtime
+├── WIF
+│   ├── pool: cursor
+│   └── provider: oidc
+│       ├── issuer: https://api.cursor.com
+│       └── condition: repo_url と agent_runtime
+└── cursor-cloud@haru256-devgist-ops.iam.gserviceaccount.com
+    └── impersonate: 許可した Cursor sub のみ
 
 haru256-devgist-app-dev
-└── cursor-cloud@haru256-devgist-app-dev.iam.gserviceaccount.com
-    ├── impersonate: 許可した Cursor sub のみ
-    └── GCS IAM (data-dev datalake)
-        ├── roles/storage.objectViewer
-        └── roles/storage.objectCreator
+└── GCS IAM (data-dev datalake へ cursor-cloud を付与)
+    ├── roles/storage.objectViewer
+    └── roles/storage.objectCreator
 
 GitHub Actions（別 WIF、本 ADR の外）
 └── terraform apply / イメージ push など CI 操作
@@ -252,11 +259,13 @@ WIF の attribute mapping は少なくとも次を含める。
 
 allowlist に使う `sub` は `user:<cursor_user_id>` のような安定 ID とする。`owner_email` は変わり得るので信頼条件に使わない。
 
-`cursor-cloud` を app-dev に置く理由は、最初の権限も今後足す権限も dev の app / data 平面にあるからである。ops に置く `github-actions` は Artifact Registry と CI 用であり、用途が違う。
+`cursor-cloud` を ops に置く理由は、後から app-dev / data-dev / ops など複数 project のリソースへ IAM を足す actor だからである。WIF と SA と impersonation allowlist を同じ project に揃え、`github-actions` と同じ置き方にする。
+
+ops の email は環境を表さない。prod の bucket や Job へ権限を足すときは、別の明示的な判断として扱う。初期 IAM は data-dev datalake だけである。
 
 ### 権限を広げるとき
 
-dev 開発用途へ広げるときは、`cursor-cloud` を増やさず、app-dev state で IAM binding を足す。
+dev 開発用途へ広げるときは、`cursor-cloud` を増やさず、対象リソースを管理している Terraform root で IAM binding を足す。app-dev のリソースなら app-dev、data-dev の別バケットならその binding を置く root、ops の読み取りなら ops または既存の cross-project パターンに従う。
 
 足す前に、その権限が Cloud Agent 実行全体に渡ることを認めるか確認する。prod の identity や GitHub Actions 用 WIF に相乗りしない。
 
@@ -273,27 +282,30 @@ dev 開発用途へ広げるときは、`cursor-cloud` を増やさず、app-dev
 
 - Cursor 環境に無期限の GCP 鍵が残らない
 - crawler runtime と Cloud Agent の権限が分かれる
-- SA 名を変えずに、dev 向け IAM を後から足せる
+- SA 名を変えずに、複数 project のリソースへ IAM を後から足せる
+- WIF、SA、impersonation allowlist が ops に揃う
 - terraform apply の実行主体が GitHub Actions に残る
 - 空の allowlist では GCP 操作が始まらない
 
 ### Negative (デメリット)
 
 - WIF と impersonation の構築が、JSON キーを 1 本置くより重い
-- allowlist の Cursor `sub` は Terraform 変数で持つ。ユーザー追加のたびに app-dev の apply が要る
+- allowlist の Cursor `sub` は Terraform 変数で持つ。ユーザー追加のたびに ops の apply が要る
+- ops の project ID は環境を表さない。prod への権限追加を命名だけでは防げない
 - OIDC socket を叩けるプロセスは、許可済みなら `cursor-cloud` として動ける。これは Cursor の trust model であり、IAM を細かくしても VM 内では分かれていない
 - 初期状態では datalake 以外の検証はできない
 
 ### Risks / Future Review (将来の課題)
 
 - `cursor-cloud` に権限を足し続けると、名前は汎用のまま実質的に何でもできる SA になる。肥大したら SA 分割を再検討する
+- ops に置いたまま prod リソースへ IAM を足すと、dev 検証用 identity が環境をまたぐ。そのときは `cursor-cloud-dev` のような分割を再検討する
 - attribute condition の `repo_url` は primary repository だけを見る。multi-repo agent では `repo_urls` の扱いで意図より広い実行が通る可能性がある
 - Cursor の JWT claim 名や issuer URL が変わった場合、WIF provider の更新が必要になる
 - GitHub Actions 用 WIF を後から足すとき、ops の pool 設計を流用しすぎると信頼条件が混ざる
 
 ## Next Steps
 
-1. Terraform で ops の Cursor 用 WIF pool / provider と、app-dev の `cursor-cloud` SA、datalake IAM、subject allowlist を定義する
+1. Terraform で ops の Cursor 用 WIF pool / provider、`cursor-cloud` SA、subject allowlist を定義する。app-dev で datalake への `objectViewer` / `objectCreator` をこの SA に付与する
 2. ローカル PC から ops → app-dev の順で apply する
 3. Cursor Cloud 側は、WIF の audience に合わせて OIDC を mint し、ADC が `cursor-cloud` を使う状態にする。これは本 ADR の Terraform 定義の後続作業である
 4. GitHub Actions から terraform apply するための WIF は、別 ADR または別 PR で設計する

--- a/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
+++ b/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
@@ -9,7 +9,9 @@
 
 ## Status (ステータス)
 
-Accepted (承認済み) - 2026-08-26
+Superseded (置き換え済み) - 2026-08-26 by [INFRA-ADR-014](./014-cursor-oidc-wif-direct-resource-access.md)
+
+`cursor-cloud` SA の impersonation は採用しない。現行方針は WIF federated principal への direct resource access である。OIDC を使い、鍵を置かず、GitHub Actions 用 WIF と混ぜない、という点は 014 でも維持する。
 
 ## Context (背景・課題)
 
@@ -312,7 +314,7 @@ dev 開発用途へ広げるときは、`cursor-cloud` を増やさず、対象�
 
 ## Related Documents
 
-- [[INFRA-ADR-004] Terraform State Project と Ops Project を分離する](./004-separate-tf-and-ops-projects.md)
+- [[INFRA-ADR-014] Cursor Cloud の GCP 権限は WIF federated principal への direct resource access とする](./014-cursor-oidc-wif-direct-resource-access.md)（現行方針）
 - [[INFRA-ADR-007] Artifact Registry リポジトリ戦略とワークロード用 Service Account 設計](./007-artifact-registry-and-sa-strategy.md)
 - [[INFRA-ADR-008] Service Account 命名規則](./008-service-account-naming.md)
 - [[INFRA-ADR-009] Cross-project IAM binding の ownership](./009-cross-project-iam-ownership.md)

--- a/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
+++ b/docs/adr/infra/013-cursor-oidc-workload-identity-federation.md
@@ -1,0 +1,235 @@
+# INFRA-ADR-013 Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用する
+
+## Conclusion (結論)
+
+- Cursor Cloud Agent が GCP を操作するときは、Cursor が発行する短命 OIDC JWT を GCP Workload Identity Federation（WIF）で交換し、dev 用 Service Account `cursor-cloud` を impersonate する。
+- Service Account JSON キーと、人間ユーザーの Application Default Credentials を Cursor 環境に置かない。
+- 初期権限は `haru256-devgist-data-dev` の datalake に対する `roles/storage.objectViewer` と `roles/storage.objectCreator` に限定する。terraform apply や Cloud Run Job 起動はこの identity に含めない。
+- terraform apply は GitHub Actions 側の別 WIF で行う。Cursor Cloud 用 WIF と混ぜない。
+
+## Status (ステータス)
+
+Accepted (承認済み) - 2026-08-26
+
+## Context (背景・課題)
+
+### 背景
+
+Cursor Cloud Agent は DevGist のコードをリモート VM で実行する。crawler の GCS 書き込み確認など、GCP 上の dev リソースに触らないと検証が閉じない作業がある。
+
+既存方針は次の通りである。
+
+- WIF と CI 用の共通 identity は Ops Project に置く（[INFRA-ADR-004](./004-separate-tf-and-ops-projects.md)）
+- ワークロード runtime SA はアプリケーション × 環境で分ける（[INFRA-ADR-007](./007-artifact-registry-and-sa-strategy.md)）
+- SA ID は `<workload-or-actor>[-<purpose>]` とし、環境名は project ID で表す（[INFRA-ADR-008](./008-service-account-naming.md)）
+- 秘密鍵は作らず、WIF または impersonation を使う（[service_accounts module](../../../infra/terraform/modules/service_accounts/main.tf)）
+- workload 固有の cross-project IAM は SA 定義側 state で管理する（[INFRA-ADR-009](./009-cross-project-iam-ownership.md)）
+
+Cursor 公式も、クラウドロールには Secrets に長寿命キーを置くより [OIDC tokens](https://cursor.com/docs/cloud-agent/identity) を使うことを推奨している。Cloud Agent VM は Unix socket から RS256 JWT を mint できる。issuer は `https://api.cursor.com`、有効期限は 5 分である。
+
+AWS には `CURSOR_AWS_ASSUME_IAM_ROLE_ARN` という Cursor 公式の role assumption がある。GCP には同等の「ARN を 1 本置く」仕組みは無い。GCP 側で WIF を自分で組む必要がある。
+
+ここで決めるのは、Cursor Cloud を GCP のどの identity として扱うか、最初に何を許可するか、誰の agent 実行を信頼するかである。
+
+### 要件と制約
+
+1. **長寿命の秘密を Cursor に置かない**
+   - snapshot やチャット、ターミナル出力に鍵が残る経路を増やしたくない
+   - 漏洩しても期限が来ない JSON キーは使わない
+
+2. **runtime と agent の blast radius を分ける**
+   - Cloud Run Job の `crawler` SA をそのまま借りると、prompt injection で本番相当の crawler 権限が使える
+   - agent VM 上の任意プロセスが OIDC socket を叩ける。信用境界は「その Cloud Agent 実行全体」である
+
+3. **今は crawler 検証、後で dev 開発全般**
+   - 最初に必要なのは datalake への読書き確認である
+   - 同じ identity を、後から dev の他リソースへ広げる余地を残したい
+   - 広げ方は「SA を増やす」ではなく「同じ SA に IAM を足す」。そのたびに Terraform で明示する
+
+4. **インフラ変更の実行主体を分けたい**
+   - terraform apply は GitHub Actions の CI で行う
+   - Cursor Cloud 用 WIF と GitHub Actions 用 WIF は別物にする
+
+5. **既存の project / state 分割を崩さない**
+   - WIF pool は ops、dev 用の操作 identity は app-dev
+   - apply 順 `ops -> app` を維持し、remote state の循環を作らない
+
+6. **信頼する Cursor 実行を絞る**
+   - このリポジトリの managed Cloud Agent であること
+   - 許可した Cursor `sub` であること
+   - Cursor の `environment_id` を GCP に固定すると、環境作り直しのたびに Terraform が必要になる
+
+### 比較した選択肢
+
+#### 認証方式
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: SA JSON キーを Cursor Secrets に置く | すぐ動かしたい場合 | 実装が短い。ADC の説明が不要 | 無期限の秘密鍵。snapshot や Runtime Secret 経由でもプロセスから読める。既存の「鍵を作らない」方針に反する | 非採用 |
+| Option B: ユーザー ADC（`gcloud auth application-default login`） | 人間の手元 PC | 手元では既に使っている | Cloud Agent で対話ログインしにくい。権限が広すぎることが多い。refresh token が disk に残る | 非採用 |
+| Option C: Cursor OIDC + GCP WIF + SA impersonation | Cursor / GitHub など外部実行基盤 | 鍵が無い。claim で repo と subject を縛れる。ADC の実体は credential config だけ | GCP 側に WIF と IAM の構築が要る。トークンは 5 分で切れる | 採用 |
+
+#### GCP 上の identity
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: Cloud Run の `crawler` SA を impersonate | agent と runtime を完全に同じ権限にしたい場合 | SA が増えない。本番パスと一致する | agent 侵害が crawler runtime と同じになる | 非採用 |
+| Option B: WIF の federated principal に直接 IAM を付ける | SA を増やしたくない場合 | impersonation が無い | 監査ログ上の principal が Cursor `sub` になり、既存の SA 運用と揃わない。権限追加のたびに principal 文字列を扱う | 非採用 |
+| Option C: dev 用の専用 SA `cursor-cloud` を impersonate | agent 用 identity を runtime から分け、後から権限を足したい場合 | blast radius を分けられる。名前が crawler に固定されない。監査は SA 単位 | SA が 1 つ増える。最初は datalake 以外何もできない | 採用 |
+
+#### 信頼する Cursor 実行
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: `repo_url` と `agent_runtime==managed` だけ | チーム全員の Cloud Agent に同じ権限を出したい場合 | 設定が少ない | このリポジトリで agent を起動できる Cursor ユーザーなら誰でも federate できる | 非採用（初期） |
+| Option B: A に加え、Cursor `sub` の allowlist | 個人開発、または許可した人だけに出したい場合 | 空の allowlist なら impersonate できない。チーム化したら ID を足せる | allowlist の更新が Terraform 変数になる | 採用 |
+| Option C: B に加え `environment_id` も GCP で固定 | 特定の Cursor Environment 以外を拒否したい場合 | 保存済み環境以外を切れる | 環境作り直しのたびに Terraform が必要 | 非採用 |
+
+### 選定観点
+
+- 長寿命の GCP 鍵を Cursor に置かないこと
+- crawler runtime と Cloud Agent の権限を分けること
+- 今の datalake 検証と、後の dev 開発用途を同じ identity で扱えること
+- terraform apply の実行主体を GitHub Actions に残すこと
+- 既存の ops / app-dev / data-dev 分割と apply 順を崩さないこと
+
+## Considered Options
+
+### Option A: SA JSON キーまたはユーザー ADC を Cursor に置く [却下]
+
+Cursor Dashboard の Runtime Secret に JSON キーを置くか、snapshot に ADC を焼き込む。
+
+却下理由:
+
+- JSON キーは期限が来ない。漏れたあとに無効化するまで使える。
+- Runtime Secret はモデル出力からは隠せるが、VM の環境変数としては残る。
+- ユーザー ADC は人間の権限をそのまま agent に渡すことが多く、最小権限にならない。
+- リポジトリの SA module は `generate_keys = false` であり、鍵を前提にした運用を始めてしまう。
+
+### Option B: Cloud Run の `crawler` SA を Cloud Agent が借りる [却下]
+
+WIF の先を既存の `crawler@haru256-devgist-app-dev.iam.gserviceaccount.com` にする。
+
+却下理由:
+
+- crawler Job と同じ GCS 権限に加え、将来 Job に付く権限がすべて agent に付く。
+- OIDC socket は VM 内の任意プロセスが使える。crawler runtime と同じ identity にする理由が、検証の都合以外に無い。
+- SA 名が crawler 固定になるため、dev 開発全般へ広げるときに名前が嘘になる。
+
+### Option C: Cursor OIDC + WIF で `cursor-cloud` を impersonate する [採用]
+
+ops に Cursor 用 WIF pool を置き、app-dev の `cursor-cloud` を短命 impersonate する。最初の IAM は datalake の読書きだけにする。
+
+採用理由:
+
+- 秘密鍵が無い。交換に使う JWT は 5 分で切れる。
+- `google.subject` に Cursor `sub` を載せ、許可した subject だけ `roles/iam.workloadIdentityUser` を付ける。
+- SA 名が actor 名なので、後から dev の別リソースへ権限を足しても命名を変えなくてよい。
+- terraform apply 用の GitHub Actions WIF とは issuer も用途も別になる。
+
+## Decision (決定事項)
+
+Cursor Cloud Agent から GCP への認証は、Cursor OIDC と GCP WIF による短命 impersonation とする。借りる identity は `cursor-cloud@haru256-devgist-app-dev.iam.gserviceaccount.com` である。
+
+### 採用方針
+
+- Cursor Cloud に SA JSON キーもユーザー ADC も置かない
+- Cloud Agent は Unix socket から OIDC JWT を mint し、GCP STS に渡す
+- JWT の `aud` は WIF provider の既定 audience（canonical resource URL）に固定する。汎用の `https://iam.googleapis.com` は使わない
+- issuer は `https://api.cursor.com`。JWKS は Cursor の discovery を使う
+- WIF pool と OIDC provider は `haru256-devgist-ops` に置く
+- impersonate 先 SA は `haru256-devgist-app-dev` の `cursor-cloud` とする。ops の `github-actions` とは別 actor である
+- `cursor-cloud` は runtime SA ではない。INFRA-ADR-008 の actor 名として `github-actions` と同じ置き方をする。環境は project ID の `app-dev` で表す
+- provider の attribute condition で、少なくとも次を要求する
+  - `assertion.repo_url == "github.com/haru-256/devgist"`
+  - `assertion.agent_runtime == "managed"`
+- `roles/iam.workloadIdentityUser` は allowlist した Cursor `sub` にだけ付ける。member は `principal://iam.googleapis.com/projects/<ops_number>/locations/global/workloadIdentityPools/<pool>/subject/<sub>` 形式とする
+- allowlist が空なら、pool はあっても impersonate できない
+- Cursor `environment_id` は GCP の信頼条件に入れない。Environment の作り直しで Terraform を変えたくない
+- `cursor-cloud` への IAM 追加は、その都度 Terraform で明示する。本 ADR は将来の権限を先に広く付与しない
+- terraform apply、tfstate、Artifact Registry への push、Cloud Run Job の実行定義変更は、GitHub Actions 用の別 WIF の責務である。その設計は本 ADR の対象外とする
+
+### 初期構成
+
+```
+haru256-devgist-ops
+└── WIF
+    ├── pool: cursor
+    └── provider: oidc
+        ├── issuer: https://api.cursor.com
+        └── condition: repo_url と agent_runtime
+
+haru256-devgist-app-dev
+└── cursor-cloud@haru256-devgist-app-dev.iam.gserviceaccount.com
+    ├── impersonate: 許可した Cursor sub のみ
+    └── GCS IAM (data-dev datalake)
+        ├── roles/storage.objectViewer
+        └── roles/storage.objectCreator
+
+GitHub Actions（別 WIF、本 ADR の外）
+└── terraform apply / イメージ push など CI 操作
+```
+
+WIF の attribute mapping は少なくとも次を含める。
+
+- `google.subject` = `assertion.sub`
+- `attribute.repo` = `assertion.repo_url`
+- `attribute.runtime` = `assertion.agent_runtime`
+
+allowlist に使う `sub` は `user:<cursor_user_id>` のような安定 ID とする。`owner_email` は変わり得るので信頼条件に使わない。
+
+`cursor-cloud` を app-dev に置く理由は、最初の権限も今後足す権限も dev の app / data 平面にあるからである。ops に置く `github-actions` は Artifact Registry と CI 用であり、用途が違う。
+
+### 権限を広げるとき
+
+dev 開発用途へ広げるときは、`cursor-cloud` を増やさず、app-dev state で IAM binding を足す。
+
+足す前に、その権限が Cloud Agent 実行全体に渡ることを認めるか確認する。prod の identity や GitHub Actions 用 WIF に相乗りしない。
+
+### 再検討条件
+
+- Cursor が GCP 向けの公式 assume 機能を出した場合
+- チーム開発になり、`sub` allowlist より `team_id` を `sub` に投影する方が運用しやすい場合
+- `cursor-cloud` の権限が肥大し、workload ごとに SA を分けた方が blast radius を説明しやすい場合
+- GitHub Actions 用 WIF を導入するとき、ops の pool を共有するか provider を分けるかを別 ADR で決める必要が出た場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- Cursor 環境に無期限の GCP 鍵が残らない
+- crawler runtime と Cloud Agent の権限が分かれる
+- SA 名を変えずに、dev 向け IAM を後から足せる
+- terraform apply の実行主体が GitHub Actions に残る
+- 空の allowlist では GCP 操作が始まらない
+
+### Negative (デメリット)
+
+- WIF と impersonation の構築が、JSON キーを 1 本置くより重い
+- allowlist の Cursor `sub` は Terraform 変数で持つ。ユーザー追加のたびに app-dev の apply が要る
+- OIDC socket を叩けるプロセスは、許可済みなら `cursor-cloud` として動ける。これは Cursor の trust model であり、IAM を細かくしても VM 内では分かれていない
+- 初期状態では datalake 以外の検証はできない
+
+### Risks / Future Review (将来の課題)
+
+- `cursor-cloud` に権限を足し続けると、名前は汎用のまま実質的に何でもできる SA になる。肥大したら SA 分割を再検討する
+- attribute condition の `repo_url` は primary repository だけを見る。multi-repo agent では `repo_urls` の扱いで意図より広い実行が通る可能性がある
+- Cursor の JWT claim 名や issuer URL が変わった場合、WIF provider の更新が必要になる
+- GitHub Actions 用 WIF を後から足すとき、ops の pool 設計を流用しすぎると信頼条件が混ざる
+
+## Next Steps
+
+1. Terraform で ops の Cursor 用 WIF pool / provider と、app-dev の `cursor-cloud` SA、datalake IAM、subject allowlist を定義する
+2. ローカル PC から ops → app-dev の順で apply する
+3. Cursor Cloud 側は、WIF の audience に合わせて OIDC を mint し、ADC が `cursor-cloud` を使う状態にする。これは本 ADR の Terraform 定義の後続作業である
+4. GitHub Actions から terraform apply するための WIF は、別 ADR または別 PR で設計する
+
+## Related Documents
+
+- [[INFRA-ADR-004] Terraform State Project と Ops Project を分離する](./004-separate-tf-and-ops-projects.md)
+- [[INFRA-ADR-007] Artifact Registry リポジトリ戦略とワークロード用 Service Account 設計](./007-artifact-registry-and-sa-strategy.md)
+- [[INFRA-ADR-008] Service Account 命名規則](./008-service-account-naming.md)
+- [[INFRA-ADR-009] Cross-project IAM binding の ownership](./009-cross-project-iam-ownership.md)
+- [service_accounts module](../../../infra/terraform/modules/service_accounts/README.md)
+- [Cursor Cloud Agent OIDC tokens](https://cursor.com/docs/cloud-agent/identity)
+- [GCP Workload Identity Federation with other identity providers](https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers)

--- a/docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md
+++ b/docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md
@@ -1,0 +1,246 @@
+# INFRA-ADR-014 Cursor Cloud の GCP 権限は WIF federated principal への direct resource access とする
+
+## Conclusion (結論)
+
+- Cursor Cloud Agent が GCP を操作するときは、Cursor OIDC JWT を WIF で federated token に換え、その federated principal へリソース IAM を直接付ける。Service Account を impersonate しない。
+- Service Account JSON キーと、人間ユーザーの Application Default Credentials を Cursor 環境に置かない。
+- 初期権限は `haru256-devgist-data-dev` の datalake に対する `roles/storage.objectViewer` と `roles/storage.objectCreator` に限定する。terraform apply や Cloud Run Job 起動はこの identity に含めない。
+- terraform apply は GitHub Actions 側の別 WIF で行う。Cursor Cloud 用 WIF と混ぜない。
+
+## Status (ステータス)
+
+Accepted (承認済み) - 2026-08-26
+
+[INFRA-ADR-013](./013-cursor-oidc-workload-identity-federation.md) を supersede する。013 が決めた「OIDC + WIF、鍵を置かない、crawler runtime と分ける、GHA と混ぜない」は維持し、権限の付け方だけを差し替える。
+
+## Context (背景・課題)
+
+### 背景
+
+[INFRA-ADR-013](./013-cursor-oidc-workload-identity-federation.md) は、Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用し、ops の `cursor-cloud` SA を impersonate するとした。
+
+その直後の実装レビューで、GCP 公式が WIF の既定として **direct resource access** を推奨している点が問題になった。公式概要は次の通りである。
+
+> We recommend that you use Workload Identity Federation to provide access directly to a Google Cloud resource. Although most Google Cloud APIs support Workload Identity Federation, some APIs have limitations. As an alternative, you can use service account impersonation.
+>
+> — [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+
+初期に触る API は Cloud Storage の object 読書きである。この用途は federated principal への resource IAM で足り、impersonation が必要になる制限には当たらない。
+
+013 が SA を選んだ理由は、監査を SA 単位に揃えることと、権限追加を SA 1 本に足せることだった。direct access では監査ログの principal は Cursor `sub` になり、リソースを足すたびに同じ principal へ IAM を足す。hop が 1 段減り、`iamcredentials` も `cursor-cloud` SA も要らない。
+
+### 要件と制約
+
+1. **長寿命の秘密を Cursor に置かない**（013 から維持）
+2. **runtime と agent の blast radius を分ける**（013 から維持。crawler SA は借りない）
+3. **今は crawler 検証、後で dev 開発全般**
+   - 最初は datalake の読書きだけ
+   - 広げ方は「同じ federated principal に、対象リソース側 root で IAM を足す」
+4. **インフラ変更の実行主体を分ける**（013 から維持。GHA 用 WIF とは別）
+5. **既存の project / state 分割を崩さない**
+   - WIF pool / provider は ops
+   - リソース IAM は、そのリソースを既に扱っている root（初期は app-dev）
+   - ops は data の remote state を読まない
+6. **信頼する Cursor 実行を絞る**
+   - provider condition: `repo_url` と `agent_runtime == managed`
+   - リソース IAM: 許可した Cursor `sub` の `principal://.../subject/<sub>` だけ
+   - `environment_id` は GCP に固定しない
+
+### 比較した選択肢
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: 013 どおり `cursor-cloud` を impersonate | 監査を SA email に揃えたい場合。federated identity 非対応 API がある場合 | 権限追加は SA に 1 回。既存の SA 運用と見た目が揃う | hop が増える。`iamcredentials` と SA が要る。GCP の推奨と逆 | 非採用 |
+| Option B: federated principal へ direct resource access | GCS など対応済み API だけを触る場合 | hop が無い。SA が増えない。監査が Cursor `sub` そのもの | リソースを足すたびに principal 文字列へ IAM を足す | 採用 |
+| Option C: Cloud Run の `crawler` SA を借りる | agent と runtime を同じ権限にしたい場合 | SA が増えない | agent 侵害が crawler runtime と同じになる | 非採用 |
+
+### 選定観点
+
+- GCP 公式が direct access を推奨し、impersonation を代替としていること
+- 初期 API（GCS object 読書き）が federated principal をサポートしていること
+- crawler runtime SA を借りないこと
+- apply 順 `ops -> app` と INFRA-ADR-009 の IAM ownership を崩さないこと
+
+## Considered Options
+
+### Option A: `cursor-cloud` SA を impersonate する [却下]
+
+013 の採用案。WIF のあとに `roles/iam.workloadIdentityUser` で SA を借り、SA に GCS IAM を付ける。
+
+却下理由:
+
+- GCP は direct access を推奨し、impersonation は API 制限があるときの代替である
+- 初期に使う GCS object IAM はその制限に当たらない
+- SA と IAM Credentials API が、今の要件に対して余分である
+
+### Option B: federated principal へ direct resource access する [採用]
+
+STS が出した federated token を、そのまま GCS などへ使う。IAM member は `principal://iam.googleapis.com/projects/<ops_number>/locations/global/workloadIdentityPools/cursor/subject/<sub>` である。
+
+採用理由:
+
+- GCP の推奨経路である
+- impersonation hop が無い
+- `cursor-cloud` SA を作らない
+- allowlist が空なら、リソース IAM member が無いので GCS に届かない
+- 権限を広げるときは、対象リソースを管理している root に同じ principal を足す。ops に IAM を集めない
+
+### Option C: crawler runtime SA を借りる [却下]
+
+013 と同じ理由で却下する。agent と Job runtime の blast radius を分けたい。
+
+## Decision (決定事項)
+
+Cursor Cloud Agent から GCP への認証は Cursor OIDC と WIF とする。権限は federated principal への direct resource access で付ける。`cursor-cloud` Service Account は作らない。
+
+### 認証の流れ
+
+```mermaid
+flowchart LR
+  subgraph cursorSide [Cursor Cloud]
+    Agent[Cloud Agent VM]
+    Socket[OIDC socket]
+    Agent --> Socket
+  end
+
+  subgraph opsProject [haru256-devgist-ops]
+    Pool[WIF pool cursor]
+    Provider[OIDC provider oidc]
+    Pool --> Provider
+  end
+
+  subgraph dataProject [haru256-devgist-data-dev]
+    GCS[datalake bucket]
+  end
+
+  Socket -->|"JWT 5 min"| Sts[GCP STS]
+  Sts --> Provider
+  Provider -->|"federated token"| GCS
+```
+
+1. Cloud Agent が WIF provider の既定 audience を付けて JWT を mint する
+2. Cursor が RS256 JWT を返す。`iss` は `https://api.cursor.com`、寿命は 5 分、`sub` は Cursor ユーザーの安定 ID
+3. GCP STS が JWKS で署名を検証し、ops の provider で `aud`、`repo_url`、`agent_runtime` を確認する
+4. 条件を満たせば federated token を出す。`google.subject` は JWT の `sub`
+5. GCS は、その `principal://.../subject/<sub>` に付いた IAM だけで読書きを許す。JWT 自体に GCS 権限は無い
+
+```mermaid
+sequenceDiagram
+  participant Agent as CloudAgent
+  participant Socket as CursorOIDC
+  participant Sts as GCP_STS
+  participant Jwks as CursorJWKS
+  participant Provider as WIF_provider
+  participant Gcs as datalake
+
+  Agent->>Socket: mint JWT with provider audience
+  Socket-->>Agent: RS256 JWT
+  Note over Agent,Socket: iss api.cursor.com, sub user id, 5 min
+  Agent->>Sts: exchange JWT
+  Sts->>Jwks: verify signature
+  Sts->>Provider: check aud, repo_url, agent_runtime
+  alt audience or condition mismatch
+    Provider-->>Agent: reject
+  else JWT accepted
+    Sts-->>Agent: federated token
+    alt sub has no resource IAM
+      Gcs-->>Agent: permission denied
+    else sub allowlisted on the bucket
+      Agent->>Gcs: objectViewer and objectCreator
+    end
+  end
+```
+
+### 採用方針
+
+- Cursor Cloud に SA JSON キーもユーザー ADC も置かない
+- Cloud Agent は Unix socket から OIDC JWT を mint し、GCP STS に渡す
+- JWT の `aud` は WIF provider の既定 audience に固定する
+- issuer は `https://api.cursor.com`
+- WIF pool と OIDC provider は `haru256-devgist-ops` に置く。pool ID は `cursor`、provider ID は `oidc`
+- impersonate 先の Service Account は置かない。`iamcredentials.googleapis.com` も Cursor 用には有効化しない
+- リソース IAM は ops に集めない。INFRA-ADR-009 に従い、そのリソースを既に扱っている root が federated principal を member にする。初期の datalake 読書きは app-dev
+- provider の attribute mapping は少なくとも次を含む
+  - `google.subject` = `assertion.sub`
+  - `attribute.repo` = `assertion.repo_url`
+  - `attribute.runtime` = `assertion.agent_runtime`
+- provider の attribute condition は少なくとも次を要求する
+  - `assertion.repo_url == "github.com/haru-256/devgist"`
+  - `assertion.agent_runtime == "managed"`
+- datalake IAM の member は `principal://iam.googleapis.com/projects/<ops_number>/locations/global/workloadIdentityPools/cursor/subject/<sub>` とする。`sub` の allowlist は app-dev の変数 `cursor_oidc_subjects` に置く
+- allowlist が空なら IAM member が無いので、GCS には届かない
+- Cursor `environment_id` は GCP の信頼条件に入れない
+- 権限追加はその都度 Terraform で明示する。本 ADR は将来の権限を先に広く付与しない
+- federated identity 非対応の API が必要になったときだけ、SA impersonation を再検討する
+
+### 初期構成
+
+```
+haru256-devgist-ops
+└── WIF
+    ├── pool: cursor
+    └── provider: oidc
+        ├── issuer: https://api.cursor.com
+        └── condition: repo_url と agent_runtime
+
+haru256-devgist-app-dev
+└── GCS IAM (data-dev datalake へ federated principal を付与)
+    ├── roles/storage.objectViewer
+    └── roles/storage.objectCreator
+        └── member: principal://.../workloadIdentityPools/cursor/subject/<allowlisted sub>
+
+GitHub Actions（別 WIF、本 ADR の外）
+└── terraform apply / イメージ push など CI 操作
+```
+
+allowlist に使う `sub` は `user:<cursor_user_id>` のような安定 ID とする。`owner_email` は使わない。
+
+### 権限を広げるとき
+
+同じ Cursor `sub` の principal を、対象リソースを管理している Terraform root で IAM member に足す。新しい SA は増やさない。prod リソースへ足すときは、別の明示的な判断として扱う。
+
+### 再検討条件
+
+- 使いたい Google Cloud API が federated identity に対応していない場合（そのときだけ SA impersonation）
+- Cursor が GCP 向けの公式 assume 機能を出した場合
+- チーム開発になり、`sub` allowlist より `team_id` を `sub` に投影する方が運用しやすい場合
+- GitHub Actions 用 WIF を導入するとき、ops の pool を共有するか provider を分けるかを別 ADR で決める必要が出た場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- GCP 公式の推奨経路に揃う
+- impersonation hop と `cursor-cloud` SA が無い
+- 監査ログの principal が Cursor `sub` になる
+- 空の allowlist では GCS 操作が始まらない
+- terraform apply の実行主体が GitHub Actions に残る
+
+### Negative (デメリット)
+
+- リソースを足すたびに、同じ principal 文字列へ IAM binding を足す
+- 既存の workload は SA email で監査しているので、Cursor 経路だけ principal URL になる
+- allowlist の Cursor `sub` は Terraform 変数で持つ。ユーザー追加のたびに app-dev の apply が要る
+- OIDC socket を叩けるプロセスは、許可済みならその `sub` として動ける
+
+### Risks / Future Review (将来の課題)
+
+- federated identity 非対応 API が出たら、その API だけ SA impersonation に寄せる
+- app-dev 以外の root に同じ principal を足し続けると、誰が何を許可したかの見通しが SA 1 本より散らばる。Policy Analyzer で監査する
+- attribute condition の `repo_url` は primary repository だけを見る
+- Cursor の JWT claim 名や issuer URL が変わった場合、WIF provider の更新が必要になる
+
+## Next Steps
+
+1. Terraform で ops の Cursor 用 WIF pool / provider を定義する。app-dev で datalake へ federated principal の `objectViewer` / `objectCreator` を付与する
+2. ローカル PC から ops → app-dev の順で apply する
+3. Cursor Cloud 側は、WIF の audience に合わせて OIDC を mint し、ADC が federated token を直接使う状態にする。credential config に `service_account_impersonation_url` は入れない
+4. GitHub Actions から terraform apply するための WIF は、別 ADR または別 PR で設計する
+
+## Related Documents
+
+- [[INFRA-ADR-013] Cursor Cloud から GCP への認証に Cursor OIDC と WIF を採用する](./013-cursor-oidc-workload-identity-federation.md)（superseded）
+- [[INFRA-ADR-004] Terraform State Project と Ops Project を分離する](./004-separate-tf-and-ops-projects.md)
+- [[INFRA-ADR-009] Cross-project IAM binding の ownership](./009-cross-project-iam-ownership.md)
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [Download credential configuration and grant access](https://cloud.google.com/iam/docs/workload-download-cred-and-grant-access)

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,7 +45,7 @@ graph TD
 - `haru256-devgist-ops`
   - Artifact Registry
   - GitHub Actions 連携、WIF、共通 CI/CD 用 Service Account などの運用基盤
-  - Cursor Cloud 用 OIDC WIF pool / provider と `cursor-cloud` Service Account（[INFRA-ADR-013](../docs/adr/infra/013-cursor-oidc-workload-identity-federation.md)）
+  - Cursor Cloud 用 OIDC WIF pool / provider（[INFRA-ADR-014](../docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md)）
 
 - `haru256-devgist-data-{env}`
   - GCS datalake
@@ -89,17 +89,17 @@ graph LR
 1. `devgist-tf`
    - tfstate bucket を先に作成する
 2. `devgist-ops`
-   - `Artifact Registry`、Cursor 用 WIF、`cursor-cloud` SA など共通運用基盤を作成する
+   - `Artifact Registry`、Cursor 用 WIF など共通運用基盤を作成する
 3. `devgist-data/dev`
    - datalake など crawler の保存先を作成する
 4. `devgist-app/dev`
    - `terraform_remote_state` で `ops/data` の outputs を参照しながら app 側 compute を作成する
-   - `cursor-cloud` へ data-dev datalake の `objectViewer` / `objectCreator` を付与する
+   - Cursor Cloud の federated principal へ data-dev datalake の `objectViewer` / `objectCreator` を付与する
 
 ### Notes
 
 - `devgist-app/dev` は `devgist-ops` と `devgist-data/dev` の outputs を `terraform_remote_state` で参照する
 - secret は Terraform outputs では渡さず、`GCP Secret Manager` を app runtime から参照する
 - 旧 `environments/crawler` は legacy 扱いで、最終的には `ops/app/data` 側へ整理する
-- Cursor Cloud の subject allowlist（`cursor_oidc_subjects`）は ops の gitignore 済み `terraform.tfvars` に書く。空なら impersonate できない
-- Cursor 用 WIF と GitHub Actions 用 WIF は別物である。後者はこのディレクトリではまだ定義しない
+- Cursor Cloud の subject allowlist（`cursor_oidc_subjects`）は app-dev の gitignore 済み `terraform.tfvars` に書く。空なら datalake IAM member が付かない
+- Cursor 用 WIF は federated principal への direct resource access である。GitHub Actions 用 WIF は別物で、このディレクトリではまだ定義しない

--- a/infra/README.md
+++ b/infra/README.md
@@ -30,7 +30,7 @@
 ```mermaid
 graph TD
     TF[haru256-devgist-tf<br/>Terraform state only]
-    OPS[haru256-devgist-ops<br/>Artifact Registry / CI-CD]
+    OPS[haru256-devgist-ops<br/>Artifact Registry / CI-CD / Cursor WIF]
     DATA[haru256-devgist-data-{env}<br/>Stateful data]
     APP[haru256-devgist-app-{env}<br/>Stateless compute]
 
@@ -45,6 +45,7 @@ graph TD
 - `haru256-devgist-ops`
   - Artifact Registry
   - GitHub Actions 連携、WIF、共通 CI/CD 用 Service Account などの運用基盤
+  - Cursor Cloud 用 OIDC WIF pool / provider と `cursor-cloud` Service Account（[INFRA-ADR-013](../docs/adr/infra/013-cursor-oidc-workload-identity-federation.md)）
 
 - `haru256-devgist-data-{env}`
   - GCS datalake
@@ -88,14 +89,17 @@ graph LR
 1. `devgist-tf`
    - tfstate bucket を先に作成する
 2. `devgist-ops`
-   - `Artifact Registry` など共通運用基盤を作成する
+   - `Artifact Registry`、Cursor 用 WIF、`cursor-cloud` SA など共通運用基盤を作成する
 3. `devgist-data/dev`
    - datalake など crawler の保存先を作成する
 4. `devgist-app/dev`
    - `terraform_remote_state` で `ops/data` の outputs を参照しながら app 側 compute を作成する
+   - `cursor-cloud` へ data-dev datalake の `objectViewer` / `objectCreator` を付与する
 
 ### Notes
 
 - `devgist-app/dev` は `devgist-ops` と `devgist-data/dev` の outputs を `terraform_remote_state` で参照する
 - secret は Terraform outputs では渡さず、`GCP Secret Manager` を app runtime から参照する
 - 旧 `environments/crawler` は legacy 扱いで、最終的には `ops/app/data` 側へ整理する
+- Cursor Cloud の subject allowlist（`cursor_oidc_subjects`）は ops の gitignore 済み `terraform.tfvars` に書く。空なら impersonate できない
+- Cursor 用 WIF と GitHub Actions 用 WIF は別物である。後者はこのディレクトリではまだ定義しない

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -75,7 +75,19 @@ infra/terraform/
 │   │   ├── main.tf
 │   │   ├── providers.tf
 │   │   └── variables.tf
-│   └── tfstate_gcs_bucket/
+│   ├── service_accounts/
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── variables.tf
+│   │   └── README.md
+│   ├── tfstate_gcs_bucket/
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── variables.tf
+│   │   └── README.md
+│   └── workload_identity_oidc/
 │       ├── main.tf
 │       ├── outputs.tf
 │       ├── providers.tf
@@ -93,7 +105,7 @@ make/
 GCP project ごとに root module を配置し、必要に応じて `dev/` などの環境サブディレクトリを切ります。
 
 - `devgist-tf/`: Terraform state 管理用 project の root module
-- `devgist-ops/`: Artifact Registry などの共通運用基盤 project の root module
+- `devgist-ops/`: Artifact Registry、Cursor 用 WIF、共通 Service Account などの運用基盤 project の root module
 - `devgist-data/dev/`: 開発環境の data project 用 root module
 - `devgist-app/dev/`: 開発環境の app project 用 root module
 
@@ -103,7 +115,9 @@ GCP project ごとに root module を配置し、必要に応じて `dev/` な�
 - `artifact_registry/`: Artifact Registry repository を作成する module
 - `datalake/`: GCP のデータレイク用 GCS バケットを作成する module
 - `google_project_services/`: GCP の API 有効化を行う module
+- `service_accounts/`: Service Account と IAM（project role / actAs / WIF impersonation）をまとめる module
 - `tfstate_gcs_bucket/`: Terraform の state 管理用 GCS バケットを作成する module
+- `workload_identity_oidc/`: 汎用 OIDC Workload Identity Federation の pool と provider を作る module
 
 ### `make/`
 リポジトリ直下にあり、リポジトリ全体で再利用する Makefile 断片を配置します。
@@ -116,6 +130,7 @@ GCP project ごとに root module を配置し、必要に応じて `dev/` な�
 - root module は `environments/<env>/<service>` に配置し、環境ごとの入力値は `terraform.tfvars` で管理します。
 - module の追加・更新は `modules/` 配下に集約し、root module 側で呼び出します。
 - `terraform.tfstate` は環境ごとの状態を保持します。リモート backend を使う場合は `backend.tf` で設定します。
+- Cursor Cloud 用 WIF（pool `cursor` / provider `oidc`）と SA `cursor-cloud` は `devgist-ops` で定義する。datalake への `objectViewer` / `objectCreator` は `devgist-app/dev` が付与する。apply 順は ops → app。`cursor_wif_audience` と `cursor_cloud_service_account_email` は後続の OIDC mint で使う。
 
 ## for_each を使う場合の outputs 出力
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -130,7 +130,7 @@ GCP project ごとに root module を配置し、必要に応じて `dev/` な�
 - root module は `environments/<env>/<service>` に配置し、環境ごとの入力値は `terraform.tfvars` で管理します。
 - module の追加・更新は `modules/` 配下に集約し、root module 側で呼び出します。
 - `terraform.tfstate` は環境ごとの状態を保持します。リモート backend を使う場合は `backend.tf` で設定します。
-- Cursor Cloud 用 WIF（pool `cursor` / provider `oidc`）と SA `cursor-cloud` は `devgist-ops` で定義する。datalake への `objectViewer` / `objectCreator` は `devgist-app/dev` が付与する。apply 順は ops → app。`cursor_wif_audience` と `cursor_cloud_service_account_email` は後続の OIDC mint で使う。
+- Cursor Cloud 用 WIF（pool `cursor` / provider `oidc`）は `devgist-ops` で定義する。datalake への `objectViewer` / `objectCreator` は `devgist-app/dev` が federated principal に直接付与する。apply 順は ops → app。`cursor_wif_audience` は後続の OIDC mint で使う。credential config に SA impersonation は入れない。
 
 ## for_each を使う場合の outputs 出力
 

--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -16,6 +16,21 @@ locals {
       repository_id = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_id
     }
   }
+
+  cursor_oidc_datalake_roles = toset([
+    "roles/storage.objectViewer",
+    "roles/storage.objectCreator",
+  ])
+
+  cursor_oidc_datalake_bindings = {
+    for pair in setproduct(var.cursor_oidc_subjects, local.cursor_oidc_datalake_roles) :
+    "${pair[0]}|${pair[1]}" => {
+      subject = pair[0]
+      role    = pair[1]
+    }
+  }
+
+  cursor_wif_subject_prefix = "principal://iam.googleapis.com/projects/${data.terraform_remote_state.ops.outputs.ops_project_number}/locations/global/workloadIdentityPools/${data.terraform_remote_state.ops.outputs.cursor_wif_pool_id}/subject"
 }
 
 data "google_project" "project" {
@@ -94,14 +109,14 @@ resource "google_storage_bucket_iam_member" "crawler" {
   member = module.service_accounts.members["crawler"]
 }
 
-# data環境のGCSバケットに対して、ops の cursor-cloud に読み込み・書き込み権限を付与
-# Cloud Agent 検証用。crawler runtime SA とは別 identity（INFRA-ADR-013）
-resource "google_storage_bucket_iam_member" "cursor_cloud" {
-  for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
+# data環境のGCSバケットに対して、Cursor Cloud の federated principal に読み込み・書き込み権限を付与
+# WIF direct resource access。crawler runtime SA とは別 identity（INFRA-ADR-014）
+resource "google_storage_bucket_iam_member" "cursor_oidc" {
+  for_each = local.cursor_oidc_datalake_bindings
 
   bucket = data.terraform_remote_state.data.outputs.datalake_bucket_name
-  role   = each.value
-  member = data.terraform_remote_state.ops.outputs.cursor_cloud_service_account_member
+  role   = each.value.role
+  member = "${local.cursor_wif_subject_prefix}/${each.value.subject}"
 }
 
 # Crawler用のCloud Run Job の作成

--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -94,6 +94,16 @@ resource "google_storage_bucket_iam_member" "crawler" {
   member = module.service_accounts.members["crawler"]
 }
 
+# data環境のGCSバケットに対して、ops の cursor-cloud に読み込み・書き込み権限を付与
+# Cloud Agent 検証用。crawler runtime SA とは別 identity（INFRA-ADR-013）
+resource "google_storage_bucket_iam_member" "cursor_cloud" {
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
+
+  bucket = data.terraform_remote_state.data.outputs.datalake_bucket_name
+  role   = each.value
+  member = data.terraform_remote_state.ops.outputs.cursor_cloud_service_account_member
+}
+
 # Crawler用のCloud Run Job の作成
 resource "google_cloud_run_v2_job" "crawler" {
   name                = "crawler"

--- a/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
+++ b/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
@@ -7,6 +7,7 @@ override_data {
       ops_project_id                                = "mock-ops-project"
       crawler_artifact_registry_repository_id       = "mock-crawler-repo"
       crawler_artifact_registry_repository_location = "us-central1"
+      cursor_cloud_service_account_member           = "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
     }
   }
 }
@@ -101,5 +102,28 @@ run "reject_space_separated_crawler_conference_names" {
   expect_failures = [
     var.crawler_conference_names,
   ]
+}
+
+run "grant_cursor_cloud_datalake_read_write" {
+  command = plan
+
+  variables {
+    crawler_conference_names = "recsys"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectViewer"].member == "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
+    error_message = "Expected cursor-cloud objectViewer member from ops remote state"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectCreator"].member == "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
+    error_message = "Expected cursor-cloud objectCreator member from ops remote state"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectViewer"].bucket == "mock-datalake-bucket"
+    error_message = "Expected cursor-cloud IAM on the data-dev datalake bucket"
+  }
 }
 

--- a/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
+++ b/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
@@ -7,7 +7,8 @@ override_data {
       ops_project_id                                = "mock-ops-project"
       crawler_artifact_registry_repository_id       = "mock-crawler-repo"
       crawler_artifact_registry_repository_location = "us-central1"
-      cursor_cloud_service_account_member           = "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
+      ops_project_number                            = "123456789"
+      cursor_wif_pool_id                            = "cursor"
     }
   }
 }
@@ -104,26 +105,41 @@ run "reject_space_separated_crawler_conference_names" {
   ]
 }
 
-run "grant_cursor_cloud_datalake_read_write" {
+run "grant_cursor_oidc_datalake_read_write" {
   command = plan
 
   variables {
     crawler_conference_names = "recsys"
+    cursor_oidc_subjects     = ["user:308716925"]
   }
 
   assert {
-    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectViewer"].member == "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
-    error_message = "Expected cursor-cloud objectViewer member from ops remote state"
+    condition     = google_storage_bucket_iam_member.cursor_oidc["user:308716925|roles/storage.objectViewer"].member == "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/cursor/subject/user:308716925"
+    error_message = "Expected Cursor OIDC objectViewer member to be the WIF federated principal"
   }
 
   assert {
-    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectCreator"].member == "serviceAccount:cursor-cloud@mock-ops-project.iam.gserviceaccount.com"
-    error_message = "Expected cursor-cloud objectCreator member from ops remote state"
+    condition     = google_storage_bucket_iam_member.cursor_oidc["user:308716925|roles/storage.objectCreator"].member == "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/cursor/subject/user:308716925"
+    error_message = "Expected Cursor OIDC objectCreator member to be the WIF federated principal"
   }
 
   assert {
-    condition     = google_storage_bucket_iam_member.cursor_cloud["roles/storage.objectViewer"].bucket == "mock-datalake-bucket"
-    error_message = "Expected cursor-cloud IAM on the data-dev datalake bucket"
+    condition     = google_storage_bucket_iam_member.cursor_oidc["user:308716925|roles/storage.objectViewer"].bucket == "mock-datalake-bucket"
+    error_message = "Expected Cursor OIDC IAM on the data-dev datalake bucket"
+  }
+}
+
+run "skip_cursor_oidc_datalake_when_allowlist_empty" {
+  command = plan
+
+  variables {
+    crawler_conference_names = "recsys"
+    cursor_oidc_subjects     = []
+  }
+
+  assert {
+    condition     = length(google_storage_bucket_iam_member.cursor_oidc) == 0
+    error_message = "Expected no Cursor OIDC datalake IAM when the subject allowlist is empty"
   }
 }
 

--- a/infra/terraform/environments/devgist-app/dev/variables.tf
+++ b/infra/terraform/environments/devgist-app/dev/variables.tf
@@ -45,3 +45,17 @@ variable "crawler_conference_names" {
     error_message = "crawler_conference_names must be a comma-separated list of known conference names: recsys,kdd,wsdm,www,sigir,cikm."
   }
 }
+
+variable "cursor_oidc_subjects" {
+  type        = set(string)
+  description = "Cursor OIDC subject claims allowed to access the data-dev datalake via WIF direct resource access. Empty means no federated principal gets GCS IAM. Set this in the gitignored terraform.tfvars."
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for sub in var.cursor_oidc_subjects :
+      can(regex("^(user|service_account):.+$", sub))
+    ])
+    error_message = "Each cursor_oidc_subjects value must start with \"user:\" or \"service_account:\"."
+  }
+}

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -4,7 +4,6 @@ locals {
     "artifactregistry.googleapis.com", # Artifact Registry
     "iam.googleapis.com",              # IAM
     "sts.googleapis.com",              # Security Token Service (WIF)
-    "iamcredentials.googleapis.com",   # IAM Credentials (SA impersonation)
   ]
 
   artifact_registries = {
@@ -15,13 +14,6 @@ locals {
 
   service_account_user_members = [
     for email in var.service_account_user_emails : "user:${email}"
-  ]
-
-  # Cursor OIDC の sub を WIF federated principal に変換する。
-  # allowlist が空なら impersonate できる member は無い。
-  cursor_cloud_workload_identity_users = [
-    for sub in var.cursor_oidc_subjects :
-    "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${module.cursor_wif.pool_id}/subject/${sub}"
   ]
 }
 
@@ -88,14 +80,6 @@ module "service_accounts" {
       ]
 
       service_account_users = local.service_account_user_members
-    }
-
-    cursor-cloud = {
-      description = "Service account impersonated by Cursor Cloud Agent via Workload Identity Federation"
-
-      # datalake IAM は app-dev 側で付与する。ops は data の remote state を読まない。
-      service_account_users   = local.service_account_user_members
-      workload_identity_users = local.cursor_cloud_workload_identity_users
     }
   }
 

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -3,6 +3,8 @@ locals {
   required_services = [
     "artifactregistry.googleapis.com", # Artifact Registry
     "iam.googleapis.com",              # IAM
+    "sts.googleapis.com",              # Security Token Service (WIF)
+    "iamcredentials.googleapis.com",   # IAM Credentials (SA impersonation)
   ]
 
   artifact_registries = {
@@ -13,6 +15,13 @@ locals {
 
   service_account_user_members = [
     for email in var.service_account_user_emails : "user:${email}"
+  ]
+
+  # Cursor OIDC の sub を WIF federated principal に変換する。
+  # allowlist が空なら impersonate できる member は無い。
+  cursor_cloud_workload_identity_users = [
+    for sub in var.cursor_oidc_subjects :
+    "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${module.cursor_wif.pool_id}/subject/${sub}"
   ]
 }
 
@@ -42,6 +51,26 @@ module "artifact_registries" {
   depends_on = [module.required_project_services]
 }
 
+module "cursor_wif" {
+  source = "../../modules/workload_identity_oidc"
+
+  project_id  = data.google_project.project.project_id
+  pool_id     = "cursor"
+  provider_id = "oidc"
+  issuer_uri  = "https://api.cursor.com"
+  description = "OIDC federation for Cursor Cloud Agent"
+
+  attribute_mapping = {
+    "google.subject"    = "assertion.sub"
+    "attribute.repo"    = "assertion.repo_url"
+    "attribute.runtime" = "assertion.agent_runtime"
+  }
+
+  attribute_condition = "assertion.repo_url == \"${var.cursor_oidc_repo_url}\" && assertion.agent_runtime == \"managed\""
+
+  depends_on = [module.required_project_services]
+}
+
 module "service_accounts" {
   source = "../../modules/service_accounts"
 
@@ -59,6 +88,14 @@ module "service_accounts" {
       ]
 
       service_account_users = local.service_account_user_members
+    }
+
+    cursor-cloud = {
+      description = "Service account impersonated by Cursor Cloud Agent via Workload Identity Federation"
+
+      # datalake IAM は app-dev 側で付与する。ops は data の remote state を読まない。
+      service_account_users   = local.service_account_user_members
+      workload_identity_users = local.cursor_cloud_workload_identity_users
     }
   }
 

--- a/infra/terraform/environments/devgist-ops/outputs.tf
+++ b/infra/terraform/environments/devgist-ops/outputs.tf
@@ -37,3 +37,33 @@ output "github_actions_service_account_member" {
   value       = module.service_accounts.members["github-actions"]
   description = "The IAM member string of the GitHub Actions service account"
 }
+
+output "ops_project_number" {
+  value       = data.google_project.project.number
+  description = "The GCP project number of the ops environment"
+}
+
+output "cursor_wif_pool_id" {
+  value       = module.cursor_wif.pool_id
+  description = "Workload identity pool ID for Cursor Cloud OIDC"
+}
+
+output "cursor_wif_provider_id" {
+  value       = module.cursor_wif.provider_id
+  description = "OIDC provider ID in the Cursor Cloud workload identity pool"
+}
+
+output "cursor_wif_audience" {
+  value       = module.cursor_wif.audience
+  description = "Default JWT audience for the Cursor Cloud OIDC provider. Mint tokens with this aud value."
+}
+
+output "cursor_cloud_service_account_email" {
+  value       = module.service_accounts.emails["cursor-cloud"]
+  description = "The email address of the Cursor Cloud service account"
+}
+
+output "cursor_cloud_service_account_member" {
+  value       = module.service_accounts.members["cursor-cloud"]
+  description = "The IAM member string of the Cursor Cloud service account"
+}

--- a/infra/terraform/environments/devgist-ops/outputs.tf
+++ b/infra/terraform/environments/devgist-ops/outputs.tf
@@ -57,13 +57,3 @@ output "cursor_wif_audience" {
   value       = module.cursor_wif.audience
   description = "Default JWT audience for the Cursor Cloud OIDC provider. Mint tokens with this aud value."
 }
-
-output "cursor_cloud_service_account_email" {
-  value       = module.service_accounts.emails["cursor-cloud"]
-  description = "The email address of the Cursor Cloud service account"
-}
-
-output "cursor_cloud_service_account_member" {
-  value       = module.service_accounts.members["cursor-cloud"]
-  description = "The IAM member string of the Cursor Cloud service account"
-}

--- a/infra/terraform/environments/devgist-ops/variables.tf
+++ b/infra/terraform/environments/devgist-ops/variables.tf
@@ -21,3 +21,28 @@ variable "service_account_user_emails" {
     error_message = "Each service account user email must be a valid email address."
   }
 }
+
+variable "cursor_oidc_repo_url" {
+  type        = string
+  description = "GitHub repository URL claim that Cursor OIDC tokens must match (host/owner/repo, no scheme)."
+  default     = "github.com/haru-256/devgist"
+
+  validation {
+    condition     = can(regex("^github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.cursor_oidc_repo_url))
+    error_message = "cursor_oidc_repo_url must look like github.com/owner/repo without a scheme."
+  }
+}
+
+variable "cursor_oidc_subjects" {
+  type        = set(string)
+  description = "Cursor OIDC subject claims allowed to impersonate cursor-cloud. Empty means nobody can impersonate. Set this in the gitignored terraform.tfvars."
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for sub in var.cursor_oidc_subjects :
+      can(regex("^(user|service_account):.+$", sub))
+    ])
+    error_message = "Each cursor_oidc_subjects value must start with \"user:\" or \"service_account:\"."
+  }
+}

--- a/infra/terraform/environments/devgist-ops/variables.tf
+++ b/infra/terraform/environments/devgist-ops/variables.tf
@@ -32,17 +32,3 @@ variable "cursor_oidc_repo_url" {
     error_message = "cursor_oidc_repo_url must look like github.com/owner/repo without a scheme."
   }
 }
-
-variable "cursor_oidc_subjects" {
-  type        = set(string)
-  description = "Cursor OIDC subject claims allowed to impersonate cursor-cloud. Empty means nobody can impersonate. Set this in the gitignored terraform.tfvars."
-  default     = []
-
-  validation {
-    condition = alltrue([
-      for sub in var.cursor_oidc_subjects :
-      can(regex("^(user|service_account):.+$", sub))
-    ])
-    error_message = "Each cursor_oidc_subjects value must start with \"user:\" or \"service_account:\"."
-  }
-}

--- a/infra/terraform/modules/service_accounts/README.md
+++ b/infra/terraform/modules/service_accounts/README.md
@@ -35,18 +35,10 @@ module "service_accounts" {
       service_account_users = [
         "user:admin@example.com",
       ]
-    }
 
-    cursor-cloud = {
-      description = "Service account impersonated by Cursor Cloud Agent via WIF"
-
-      service_account_users = [
-        "user:admin@example.com",
-      ]
-
-      workload_identity_users = [
-        "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/cursor/subject/user:1",
-      ]
+      # Optional. Use when a federated identity must impersonate this SA.
+      # Cursor Cloud uses WIF direct resource access instead (INFRA-ADR-014).
+      workload_identity_users = []
     }
   }
 }

--- a/infra/terraform/modules/service_accounts/README.md
+++ b/infra/terraform/modules/service_accounts/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud service accounts を作成し、Service Account 自身の権限と、Service Account を利用できる principal をまとめて管理する wrapper module です。
 
-内部では公式 module [`terraform-google-modules/service-accounts/google`](https://registry.terraform.io/modules/terraform-google-modules/service-accounts/google/latest) を利用します。DevGist 側では、SA ごとに異なる project role と `roles/iam.serviceAccountUser` / `roles/iam.serviceAccountTokenCreator` を同じ入力で扱えるように薄く包んでいます。
+内部では公式 module [`terraform-google-modules/service-accounts/google`](https://registry.terraform.io/modules/terraform-google-modules/service-accounts/google/latest) を利用します。DevGist 側では、SA ごとに異なる project role と `roles/iam.serviceAccountUser` / `roles/iam.serviceAccountTokenCreator` / `roles/iam.workloadIdentityUser` を同じ入力で扱えるように薄く包んでいます。
 
 ## 役割
 
@@ -10,6 +10,7 @@ Google Cloud service accounts を作成し、Service Account 自身の権限と�
 - SA ごとに project role を付与する
 - SA ごとに `roles/iam.serviceAccountUser` を付与する
 - SA ごとに `roles/iam.serviceAccountTokenCreator` を付与する
+- SA ごとに `roles/iam.workloadIdentityUser` を付与する
 - Service Account key は作成しない
 
 ## 入力例
@@ -35,6 +36,18 @@ module "service_accounts" {
         "user:admin@example.com",
       ]
     }
+
+    cursor-cloud = {
+      description = "Service account impersonated by Cursor Cloud Agent via WIF"
+
+      service_account_users = [
+        "user:admin@example.com",
+      ]
+
+      workload_identity_users = [
+        "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/cursor/subject/user:1",
+      ]
+    }
   }
 }
 ```
@@ -43,11 +56,11 @@ module "service_accounts" {
 
 `project_roles` は **Service Account が何をできるか** を定義します。たとえば Artifact Registry へ push する SA には `roles/artifactregistry.writer` を付与します。
 
-`service_account_users` と `token_creators` は **誰がその Service Account を使えるか** を定義します。Cloud Run Jobs などに SA を attach / actAs できればよい場合は `service_account_users` を使います。短命 token を発行して impersonation する必要がある場合だけ `token_creators` を使います。
+`service_account_users`、`token_creators`、`workload_identity_users` は **誰がその Service Account を使えるか** を定義します。Cloud Run Jobs などに SA を attach / actAs できればよい場合は `service_account_users` を使います。短命 token を発行して impersonation する必要がある場合だけ `token_creators` を使います。Workload Identity Federation の federated principal から impersonate する場合は `workload_identity_users` に `principal://` または `principalSet://` を渡します。
 
 ## 注意点
 
-- `service_account_users` と `token_creators` は `user:...`, `group:...`, `serviceAccount:...` のような IAM member 形式で渡します。
+- `service_account_users`、`token_creators`、`workload_identity_users` は `user:...`, `group:...`, `serviceAccount:...`, `principal://...` のような IAM member 形式で渡します。
 - 人間ユーザーのメールアドレスなど repository 管理外にしたい値は、root module 側の untracked `terraform.tfvars` から渡してください。
 - この module は Service Account key を作成しません。CI/CD やローカル実行では WIF または impersonation を使う前提です。
 

--- a/infra/terraform/modules/service_accounts/main.tf
+++ b/infra/terraform/modules/service_accounts/main.tf
@@ -45,10 +45,21 @@ locals {
     ]
   ])
 
+  workload_identity_user_bindings = flatten([
+    for sa_name, sa in var.service_accounts : [
+      for member in sa.workload_identity_users : {
+        sa_name = sa_name
+        role    = "roles/iam.workloadIdentityUser"
+        member  = member
+      }
+    ]
+  ])
+
   service_account_iam_bindings = {
     for binding in concat(
       local.token_creator_bindings,
       local.service_account_user_bindings,
+      local.workload_identity_user_bindings,
     ) :
     "${binding.sa_name}|${binding.role}|${binding.member}" => binding
   }

--- a/infra/terraform/modules/service_accounts/tests/plan.tftest.hcl
+++ b/infra/terraform/modules/service_accounts/tests/plan.tftest.hcl
@@ -47,8 +47,9 @@ run "accept_multiple_sas_with_all_binding_types" {
         project_roles = [
           { project = "mock-project", role = "roles/storage.objectCreator" },
         ]
-        token_creators        = ["serviceAccount:deployer@mock-project.iam.gserviceaccount.com"]
-        service_account_users = ["user:admin@example.com"]
+        token_creators          = ["serviceAccount:deployer@mock-project.iam.gserviceaccount.com"]
+        service_account_users   = ["user:admin@example.com"]
+        workload_identity_users = ["principal://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/cursor/subject/user:1"]
       }
       api-server = {
         project_roles = [
@@ -62,5 +63,13 @@ run "accept_multiple_sas_with_all_binding_types" {
   assert {
     condition     = length(output.emails) == 2
     error_message = "Expected two service accounts to be created"
+  }
+
+  assert {
+    condition = contains(
+      [for binding in google_service_account_iam_member.service_account_iam : binding.role],
+      "roles/iam.workloadIdentityUser"
+    )
+    error_message = "Expected workloadIdentityUser to be granted from workload_identity_users"
   }
 }

--- a/infra/terraform/modules/service_accounts/variables.tf
+++ b/infra/terraform/modules/service_accounts/variables.tf
@@ -24,6 +24,10 @@ Service accounts and IAM settings.
 - service_account_users:
   Members allowed to attach / actAs this service account.
   Usually used by deployer identities for Cloud Run, GCE, Cloud Functions, etc.
+
+- workload_identity_users:
+  Members allowed to impersonate this service account through Workload Identity Federation.
+  Use principal:// or principalSet:// members from a workload identity pool.
 EOT
 
   type = map(object({
@@ -37,6 +41,8 @@ EOT
     token_creators = optional(list(string), [])
 
     service_account_users = optional(list(string), [])
+
+    workload_identity_users = optional(list(string), [])
   }))
 
   default = {}

--- a/infra/terraform/modules/workload_identity_oidc/.terraform.lock.hcl
+++ b/infra/terraform/modules/workload_identity_oidc/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:p1/8oF64IGjiI47qa4OlsagwgtqGZUT5UU0Vtjv9g9M=",
+    "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
+    "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
+    "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
+    "zh:60c96075fc082d9584b9cb8f48f0d23f90fd4344e6141a417580c6bad1b21957",
+    "zh:ad82cece07a0816153e3fc6cb6d7672c6c009742dc802ab434a83d0731d94ae7",
+    "zh:aebbf8a0bd3af0b6c705d5d85ec51891f533b83dcbae7249e64a252efc6fd862",
+    "zh:bfbb19a5b46950eaf0a83cea09a5992d1b0e96792130faeb6c733609dc2913df",
+    "zh:c196b4c82d0252fa751ee3cd84433bc483b7ce7d6fcab5db0413dbaa9f218650",
+    "zh:db1c83777bc6d7fc195be83712a9f503e9a5a1f7326fd6968d9812acc53f2056",
+    "zh:dcd58beeac9d1889e5532cfcd3bd8dec5568ab06b0a81427bc9b35931b6f0178",
+    "zh:eaeedc86c2d01630a3166ae98d5138e9bf9463b2a606d7f7df6d465d1501f28f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:qf+lQn4pQLcsIzX47cjYzTGA1X9TOaY+MQapdCX0OjQ=",
+    "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
+    "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
+    "zh:5064a8ffda6f8c6b5e72842623a6dc433fd8d8e4013f9266e2636e140a674f6a",
+    "zh:5f383784682442c67a145c4c9117864da735b149aa0e6feefb7f5c0eab738e63",
+    "zh:7fb9526dfeae6e9edd61badfd2c6c64e690e332330a88ccc8deb837d8d08cfc7",
+    "zh:84d707e934b4a2d5bf8ff6ef4758328c93ece119e5fcda09686f47db4fb68e84",
+    "zh:9aab258c4a614f2c05468893891ba6af517c448389ad080831f12f4d52048646",
+    "zh:9f8d8d7c11697b36c0f5d4e54882d7448923bb8d5083a1e50ed63043cb60dda6",
+    "zh:ad9a5a714e60f31f2576b246ac6852b3423ed62ee9537cbabf7fd147207f9e77",
+    "zh:c1098525b4a7fa8aa39cef056718c0f176842defb7dc284bc66148377d5d125d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9b705921562316bdf89e2fb310c036d3cc7bb3bf973fef318da0888deea82fa",
+  ]
+}

--- a/infra/terraform/modules/workload_identity_oidc/README.md
+++ b/infra/terraform/modules/workload_identity_oidc/README.md
@@ -2,7 +2,7 @@
 
 Generic OIDC Workload Identity Federation pool and provider.
 
-This module creates one pool and one OIDC provider. It does not create service accounts or resource IAM. Callers mint a JWT whose `aud` matches the `audience` output, then impersonate a Service Account that grants `roles/iam.workloadIdentityUser` to the federated subject.
+This module creates one pool and one OIDC provider. It does not create service accounts or resource IAM. Callers mint a JWT whose `aud` matches the `audience` output, then grant IAM roles directly to the federated principal (`principal://` or `principalSet://`).
 
 ## Resources
 
@@ -53,4 +53,4 @@ module "cursor_oidc" {
 }
 ```
 
-Leave `allowed_audiences` empty so GCP accepts only the default provider audience. That value is `audience` in the module outputs.
+Leave `allowed_audiences` empty so GCP accepts only the default provider audience. That value is `audience` in the module outputs. Grant resource IAM to `principal://.../subject/<sub>`, not to a service account.

--- a/infra/terraform/modules/workload_identity_oidc/README.md
+++ b/infra/terraform/modules/workload_identity_oidc/README.md
@@ -1,0 +1,56 @@
+# workload_identity_oidc
+
+Generic OIDC Workload Identity Federation pool and provider.
+
+This module creates one pool and one OIDC provider. It does not create service accounts or resource IAM. Callers mint a JWT whose `aud` matches the `audience` output, then impersonate a Service Account that grants `roles/iam.workloadIdentityUser` to the federated subject.
+
+## Resources
+
+- `google_iam_workload_identity_pool.pool`
+- `google_iam_workload_identity_pool_provider.oidc`
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `project_id` | GCP project that owns the pool | `string` | n/a | yes |
+| `pool_id` | Workload identity pool ID | `string` | n/a | yes |
+| `provider_id` | Provider ID inside the pool | `string` | n/a | yes |
+| `issuer_uri` | OIDC issuer URI | `string` | n/a | yes |
+| `attribute_mapping` | Claim to Google STS attribute mapping | `map(string)` | n/a | yes |
+| `attribute_condition` | CEL condition that tokens must satisfy | `string` | n/a | yes |
+| `allowed_audiences` | Extra JWT audiences. Empty keeps the provider default audience only | `list(string)` | `[]` | no |
+| `pool_display_name` | Pool display name. Empty uses `pool_id` | `string` | `""` | no |
+| `provider_display_name` | Provider display name. Empty uses `provider_id` | `string` | `""` | no |
+| `description` | Description for the pool and provider | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `pool_id` | Pool ID |
+| `provider_id` | Provider ID |
+| `pool_name` | Full pool resource name |
+| `provider_name` | Full provider resource name |
+| `audience` | Default JWT audience (`https://iam.googleapis.com/<provider_name>`). Use this as `aud` when minting tokens |
+
+## Usage
+
+```hcl
+module "cursor_oidc" {
+  source = "../../modules/workload_identity_oidc"
+
+  project_id  = var.gcp_project_id
+  pool_id     = "cursor"
+  provider_id = "oidc"
+  issuer_uri  = "https://api.cursor.com"
+  attribute_mapping = {
+    "google.subject"    = "assertion.sub"
+    "attribute.repo"    = "assertion.repo_url"
+    "attribute.runtime" = "assertion.agent_runtime"
+  }
+  attribute_condition = "assertion.repo_url == \"github.com/haru-256/devgist\" && assertion.agent_runtime == \"managed\""
+}
+```
+
+Leave `allowed_audiences` empty so GCP accepts only the default provider audience. That value is `audience` in the module outputs.

--- a/infra/terraform/modules/workload_identity_oidc/main.tf
+++ b/infra/terraform/modules/workload_identity_oidc/main.tf
@@ -1,0 +1,21 @@
+resource "google_iam_workload_identity_pool" "pool" {
+  project                   = var.project_id
+  workload_identity_pool_id = var.pool_id
+  display_name              = var.pool_display_name == "" ? var.pool_id : var.pool_display_name
+  description               = var.description
+}
+
+resource "google_iam_workload_identity_pool_provider" "oidc" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.provider_id
+  display_name                       = var.provider_display_name == "" ? var.provider_id : var.provider_display_name
+  description                        = var.description
+  attribute_mapping                  = var.attribute_mapping
+  attribute_condition                = var.attribute_condition
+
+  oidc {
+    issuer_uri        = var.issuer_uri
+    allowed_audiences = length(var.allowed_audiences) > 0 ? var.allowed_audiences : null
+  }
+}

--- a/infra/terraform/modules/workload_identity_oidc/outputs.tf
+++ b/infra/terraform/modules/workload_identity_oidc/outputs.tf
@@ -1,0 +1,24 @@
+output "pool_id" {
+  description = "The workload identity pool ID."
+  value       = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+}
+
+output "provider_id" {
+  description = "The workload identity pool provider ID."
+  value       = google_iam_workload_identity_pool_provider.oidc.workload_identity_pool_provider_id
+}
+
+output "pool_name" {
+  description = "The full resource name of the workload identity pool."
+  value       = google_iam_workload_identity_pool.pool.name
+}
+
+output "provider_name" {
+  description = "The full resource name of the OIDC provider."
+  value       = google_iam_workload_identity_pool_provider.oidc.name
+}
+
+output "audience" {
+  description = "Default JWT audience for this provider. Mint OIDC tokens with this aud value."
+  value       = "https://iam.googleapis.com/${google_iam_workload_identity_pool_provider.oidc.name}"
+}

--- a/infra/terraform/modules/workload_identity_oidc/providers.tf
+++ b/infra/terraform/modules/workload_identity_oidc/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>7.18.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>7.18.0"
+    }
+  }
+}

--- a/infra/terraform/modules/workload_identity_oidc/tests/plan.tftest.hcl
+++ b/infra/terraform/modules/workload_identity_oidc/tests/plan.tftest.hcl
@@ -1,0 +1,50 @@
+mock_provider "google" {}
+mock_provider "google-beta" {}
+
+variables {
+  project_id  = "mock-project"
+  pool_id     = "cursor"
+  provider_id = "oidc"
+  issuer_uri  = "https://api.cursor.com"
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+  attribute_condition = "assertion.agent_runtime == \"managed\""
+}
+
+run "accept_pool_and_provider_ids" {
+  command = plan
+
+  assert {
+    condition     = output.pool_id == "cursor"
+    error_message = "Expected pool_id to match the input pool_id"
+  }
+
+  assert {
+    condition     = output.provider_id == "oidc"
+    error_message = "Expected provider_id to match the input provider_id"
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.oidc.oidc[0].issuer_uri == "https://api.cursor.com"
+    error_message = "Expected OIDC issuer_uri to match the input"
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.oidc.attribute_mapping["google.subject"] == "assertion.sub"
+    error_message = "Expected google.subject to map from assertion.sub"
+  }
+}
+
+run "accept_custom_audiences" {
+  command = plan
+
+  variables {
+    allowed_audiences = ["https://example.invalid"]
+  }
+
+  assert {
+    condition     = output.pool_id == "cursor"
+    error_message = "Expected pool_id to remain cursor when allowed_audiences is set"
+  }
+}

--- a/infra/terraform/modules/workload_identity_oidc/variables.tf
+++ b/infra/terraform/modules/workload_identity_oidc/variables.tf
@@ -1,0 +1,53 @@
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID where the workload identity pool is created."
+}
+
+variable "pool_id" {
+  type        = string
+  description = "The workload identity pool ID."
+}
+
+variable "provider_id" {
+  type        = string
+  description = "The workload identity pool provider ID."
+}
+
+variable "issuer_uri" {
+  type        = string
+  description = "The OIDC issuer URI of the identity provider."
+}
+
+variable "attribute_mapping" {
+  type        = map(string)
+  description = "CEL expressions that map IdP claims to Google STS attributes."
+}
+
+variable "attribute_condition" {
+  type        = string
+  description = "CEL expression that must be true for a token to be accepted."
+}
+
+variable "allowed_audiences" {
+  type        = list(string)
+  description = "Accepted JWT aud values. Empty uses the provider default audience only."
+  default     = []
+}
+
+variable "pool_display_name" {
+  type        = string
+  description = "Display name for the workload identity pool."
+  default     = ""
+}
+
+variable "provider_display_name" {
+  type        = string
+  description = "Display name for the OIDC provider."
+  default     = ""
+}
+
+variable "description" {
+  type        = string
+  description = "Description applied to the pool and provider."
+  default     = ""
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

Cursor Cloud 用の OIDC WIF を ops に置き、app-dev から data-dev datalake へ **federated principal の direct resource access**（`objectViewer` / `objectCreator`）を付ける。`cursor-cloud` SA は作らない。この PR では apply しない。

INFRA-ADR-013 の impersonation は [INFRA-ADR-014](https://github.com/haru-256/devgist/blob/cursor/cursor-oidc-wif-terraform-45e4/docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md) で supersede する。GCP は [direct resource access を推奨](https://cloud.google.com/iam/docs/workload-identity-federation)し、impersonation は API 制限があるときの代替である。初期の GCS object IAM はその制限に当たらない。

## 概要

Cursor OIDC JWT を WIF で federated token に換え、その `principal://.../subject/<sub>` にリソース IAM を直接付ける。JSON キーもユーザー ADC も、SA impersonation も使わない。

Files タブは Terraform と 014 の差分になるよう、base を #82 のブランチにしている。#82 が main に入ったら base を `main` に戻す。

## Why

- Cloud Agent から datalake を検証したいが、長寿命の GCP 鍵を Cursor に置きたくない
- crawler runtime SA とは blast radius を分ける
- apply は GitHub Actions 側の別 WIF（この PR の対象外）
- GCS が federated principal をサポートするので、SA hop を置かない

## 関連 Issue

- Depends on #82（INFRA-ADR-013。本 PR で 014 により supersede）
- ADR Next Steps 1（Terraform 定義）。mint / Secrets / `start` は次の作業

## 読み順

1. **INFRA-ADR-014** — `docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md`
2. **generic module** — `infra/terraform/modules/workload_identity_oidc/`
3. **ops 結線** — `infra/terraform/environments/devgist-ops/`（pool / provider のみ。SA なし）
4. **リソース IAM** — `infra/terraform/environments/devgist-app/dev/`（`principal://` へ GCS binding）
5. **docs** — `infra/README.md`, `infra/terraform/README.md`

## コア / 機械的

見るべきコア:

- `docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md`
- `infra/terraform/environments/devgist-ops/main.tf`
- `infra/terraform/environments/devgist-app/dev/main.tf`
- `infra/terraform/environments/devgist-app/dev/variables.tf`
- `infra/terraform/modules/workload_identity_oidc/main.tf`

機械的（スキップ可）:

- `infra/terraform/modules/workload_identity_oidc/.terraform.lock.hcl`
- 各 `tests/*.tftest.hcl`
- module / infra README

`service_accounts` の `workload_identity_users` は汎用機能として残す。Cursor 経路では使わない。

## 変更内容

- ops: STS、pool `cursor`、provider `oidc`（issuer `https://api.cursor.com`）
- ops: `cursor-cloud` SA と `iamcredentials.googleapis.com` を置かない
- mapping: `google.subject=assertion.sub`, `attribute.repo=assertion.repo_url`, `attribute.runtime=assertion.agent_runtime`
- condition: `repo_url` と `agent_runtime == managed`。`environment_id` は入れない
- app-dev: `cursor_oidc_subjects`（default 空）。member は `principal://.../subject/<sub>`
- 空の allowlist なら datalake IAM member が付かない
- Artifact Registry writer、Cloud Run Job、tfstate、objectAdmin は付けない

## 影響範囲

- この PR をマージしただけでは GCP は変わらない（apply していない）
- 手元 apply 後: ops に WIF。app-dev apply 後、allowlist した `sub` だけ datalake 読書き
- ユーザー向けアプリ挙動: なし
- GitHub Actions 用 WIF、Cursor mint / Secrets: なし

## 確認方法

ローカルで実施する（apply なし）:

- `terraform fmt -check -recursive infra/terraform`
- `terraform test`（`workload_identity_oidc`、`service_accounts`、`devgist-app/dev`。allowlist あり / 空の両方）
- tflint（上記 + `devgist-ops`）

## 手元 apply（マージ後、ローカル PC）

順は現状どおり **ops → app**。

1. app-dev の gitignore 済み `terraform.tfvars` に `cursor_oidc_subjects` へ `user:308716925` を 1 件入れる
2. ops: `make init` → `make plan` → 承認後 `make apply`
3. app-dev: 同様に plan → apply
4. `cursor_wif_audience` を控える。credential config に `service_account_impersonation_url` は入れない

## レビュー観点

- direct access にした判断（GCP 推奨、GCS は制限外、SA hop を置かない）
- mapping / condition が ADR どおりか（`environment_id` を固定していないか）
- allowlist が空のとき IAM member が付かないか
- datalake IAM が app-dev にあり、ops が data remote state を読まないか
- GitHub Actions WIF と SA impersonation を足していないか

## 補足

`cursor_wif_audience` は `https://iam.googleapis.com/` + provider の resource name。後続の OIDC mint で `aud` に使う。この PR では mint しない。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a547679-75e1-4c93-8664-28b0e47545e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a547679-75e1-4c93-8664-28b0e47545e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

