### PR TITLE
feat(scripts): Cursor Cloud の OIDC / WIF ADC 配線と手順書

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON �
 
 手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
 
-- `start` は `scripts/cursor-cloud/setup-adc.sh`。Secrets に `CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` が必要
+- プロセス環境変数は Secrets タブに置く。ダッシュボードに環境変数専用欄が無いので、秘密ではない値もここに入れる。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
+- Cloud Agent の Environment は VM の `install` / `start` / ネットワークであり、環境変数一覧ではない。`start` は `scripts/cursor-cloud/setup-adc.sh`
 - mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
 - GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う
 - datalake のバケット名は `DATA_LAKE_BUCKET_NAME`。IAM の allowlist は Terraform の `cursor_oidc_subjects`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,14 @@ ADR の判断基準、相談の境界、記録ルールなどの詳細は skill 
 - タスクの実行時に、superpowers:subagent-driven-development や superpowers:executing-plans を使わず、タスク管理や進捗報告を怠ること。
 - サブエージェントを使う場合は、タスクの難易度や複雑さに応じてmodelやreasoningを適切に選択せず、タスクの内容や進捗をユーザーに報告しないこと。
 - terraform apply やリソース変更を伴うタスクを、ユーザーの明確な同意なしに実行すること。必ずterraform plan の内容をユーザーに提示し、承認を得てから apply を実行すること。
+
+## Cursor Cloud specific instructions
+
+GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON キーもユーザー ADC も置かない。credential config に `service_account_impersonation_url` を入れない。
+
+手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
+
+- `start` は `scripts/cursor-cloud/setup-adc.sh`。Secrets に `CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` が必要
+- mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
+- GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う
+- datalake のバケット名は `DATA_LAKE_BUCKET_NAME`。IAM の allowlist は Terraform の `cursor_oidc_subjects`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON �
 
 手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
 
-- プロセス環境変数は Secrets タブに置く。ダッシュボードに環境変数専用欄が無いので、秘密ではない値もここに入れる。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
-- Cloud Agent の Environment は VM の `install` / `start` / ネットワークであり、環境変数一覧ではない。`start` は `scripts/cursor-cloud/setup-adc.sh`
+- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
+- 保存済み Environment は VM の `install` / `start` / ネットワークである。Secret の type `Environment Variable` とは別物。`start` は `scripts/cursor-cloud/setup-adc.sh`
 - mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
 - GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う
 - datalake のバケット名は `DATA_LAKE_BUCKET_NAME`。IAM の allowlist は Terraform の `cursor_oidc_subjects`

--- a/docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md
+++ b/docs/adr/infra/014-cursor-oidc-wif-direct-resource-access.md
@@ -234,7 +234,7 @@ allowlist に使う `sub` は `user:<cursor_user_id>` のような安定 ID と�
 
 1. Terraform で ops の Cursor 用 WIF pool / provider を定義する。app-dev で datalake へ federated principal の `objectViewer` / `objectCreator` を付与する
 2. ローカル PC から ops → app-dev の順で apply する
-3. Cursor Cloud 側は、WIF の audience に合わせて OIDC を mint し、ADC が federated token を直接使う状態にする。credential config に `service_account_impersonation_url` は入れない
+3. Cursor Cloud 側は、WIF の audience に合わせて OIDC を mint し、ADC が federated token を直接使う状態にする。credential config に `service_account_impersonation_url` は入れない。手順は [docs/runbooks/cursor-cloud-oidc-wif.md](../../runbooks/cursor-cloud-oidc-wif.md)
 4. GitHub Actions から terraform apply するための WIF は、別 ADR または別 PR で設計する
 
 ## Related Documents

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -22,7 +22,7 @@ sequenceDiagram
     participant Gcs as datalake
   end
 
-  Note over Start,Socket: VM 起動。Secrets が環境変数として入る
+  Note over Start,Socket: VM 起動。type Environment Variable の Secrets がプロセス環境変数として入る
   Start->>Start: cursor-wif.json を書く
   Auth->>Helper: JSON を読みヘルパーを起動
   Helper->>Socket: JWT を mint
@@ -36,7 +36,7 @@ sequenceDiagram
   Auth->>Gcs: objectViewer / objectCreator
 ```
 
-1. Secrets が環境変数として入った状態で VM が上がる。
+1. type `Environment Variable` の Secrets がプロセス環境変数として入った状態で VM が上がる。
 2. `start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`GOOGLE_APPLICATION_CREDENTIALS` はそのパスを指す。
 3. GCS などに触ると Google Auth が JSON を読む。`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` なので [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) を起動する（`jq` と `curl` が要る）。
 4. ヘルパーが VM 内 socket から Cursor OIDC JWT を mint する（寿命 5 分）。`aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま。
@@ -49,35 +49,54 @@ JSON を書くスクリプトは [`scripts/cursor-cloud/setup-adc.sh`](../../scr
 
 ## Cursor に設定するもの
 
-入れる場所は [Cloud Agents](https://cursor.com/dashboard/cloud-agents) の **Secrets タブ** と、Cloud Agent の **Environment**（install / `start` / ネットワークのマシン設定。プロセスの環境変数のことではない）。
+入れる場所は [Cloud Agents](https://cursor.com/dashboard/cloud-agents) の **Secrets** と、保存済み **Environment** である。名前が似ているが別物である。
 
-Cloud Agents のダッシュボードには、環境変数専用の欄が無い。Secrets タブに書いた値が VM の環境変数になる。下の表はどれも秘密ではない。鍵の代わりにここに置くのではなく、専用欄が無いから Secrets タブを使う。
+| ダッシュボードの名前 | 何か | この手順で触るもの |
+|---|---|---|
+| Secrets | 名前と値の組。type を選ぶ | type `Environment Variable` の 4 件 |
+| Environment | Cloud Agent のマシン設定（`install` / `start` / ネットワーク） | `start` と、egress を制限しているときの allowlist |
+
+Secrets の type は [Secrets & Network](https://cursor.com/docs/cloud-agent/security-network) の定義に従う。
+
+| type | 実行時のプロセス環境変数になるか | Cloud Agent から値が見えるか | この手順での使い方 |
+|---|---|---|---|
+| `Environment Variable` | なる | 見える。フラグや公開 URL 向け | **この手順の値はすべてこれ** |
+| `Runtime Secret` | なる | ツール結果・チャット・コミットでは `[REDACTED]` | 使わない。鍵でもない |
+| `Build Secret` | ならない（Docker build だけ） | 実行中の agent には出ない | 使わない。`start` と ADC から見えない |
+
+`Environment Variable` と `Runtime Secret` はどちらもプロセス環境変数として入る。差は agent への見せ方である。GCP の鍵はどちらにも置かない。OIDC を使う。
 
 `CURSOR_WIF_PROJECT_NUMBER` は ops の terraform output `ops_project_number` である。
 
-### Secrets タブ（環境変数として渡る）
+### Secrets（type は Environment Variable）
 
-| 名前 | 値 | 秘密か |
-|---|---|---|
-| `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` | いいえ |
-| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） | いいえ。鍵ではなく `start` が書く JSON のパス |
-| `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` | いいえ |
-| `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` | いいえ。バケット名 |
+[Secrets タブ](https://cursor.com/dashboard/cloud-agents) で次を追加し、type を `Environment Variable` にする。Environment 単位でスコープできるなら、このリポジトリの Environment に付ける。
 
-### Environment（Cloud Agent のマシン設定）
+| 名前 | 値 |
+|---|---|
+| `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） |
+| `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` |
+| `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` |
 
-ダッシュボードの Environment は「どの VM 設定で agent を起動するか」である。プロセスの環境変数一覧ではない。環境変数は上の Secrets タブから入る。
+`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく、`start` が書く JSON のパスである。
+
+type を `Runtime Secret` にすると、agent は値を `[REDACTED]` としか見えない。プロジェクト番号やパスの確認ができなくなる。type を `Build Secret` にすると、`start` も Google Auth も読めない。
+
+### Environment（マシン設定）
+
+保存済み Environment は「どの VM で agent を起動するか」である。Secret の type `Environment Variable` ではない。プロセス環境変数の一覧でもない。変数は上の Secrets から入る。
 
 | 項目 | 値 |
 |---|---|
 | `start` | `scripts/cursor-cloud/setup-adc.sh` |
-| Network allowlist（egress を制限しているときだけ） | `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` |
+| Network（egress を制限しているときだけ） | Environment の network access に `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` を足す |
 
-既存の install / snapshot は残す。リポジトリに `.cursor/environment.json` は置かない。`install` で export した変数は Build 後に残らない。mint 自体は VM 内の Unix socket で、allowlist は不要である。
+既存の `install` / snapshot は残す。リポジトリに `.cursor/environment.json` は置かない。`install` で export した変数は Build 後に残らない。mint 自体は VM 内の Unix socket で、allowlist は不要である。ネットワークの階層は [Secrets & Network](https://cursor.com/docs/cloud-agent/security-network#network-access) を見る。
 
 ### 置かないもの
 
-- Service Account JSON キー、人間ユーザーの ADC
+- Service Account JSON キー、人間ユーザーの ADC（type `Runtime Secret` でも置かない）
 - WIF pool / provider / issuer（Cursor 側に登録する欄は無い）
 - `service_account_impersonation_url`（`gcloud ... create-cred-config` に `--service-account` を付けない）
 - `cursor_oidc_subjects`（Cursor ではなく app-dev の gitignore 済み `terraform.tfvars`）
@@ -86,12 +105,12 @@ Cloud Agents のダッシュボードには、環境変数専用の欄が無い�
 
 1. ops を apply し、`ops_project_number` を控える。
 2. app-dev の `cursor_oidc_subjects` に、許可する Cursor `sub` を入れる。例: `["user:308716925"]`。`sub` はメールではない。空なら WIF は通っても GCS は拒否する。
-3. 上の「Cursor に設定するもの」を入れる。環境変数は Secrets タブ。`start` とネットワークは Environment（マシン設定）。
+3. Secrets に上の 4 件を type `Environment Variable` で入れる。Environment の `start` に `setup-adc.sh` を入れる。egress を制限しているなら GCP ホストを Environment の allowlist に足す。
 4. 新しい Cloud Agent を起動する。`start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `cursor-gcp-oidc` の絶対パスである。
 
 ## 動作確認
 
-WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本線は ADC が token を取れることである。Secrets タブの値が入っていれば export は不要。
+WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本線は ADC が token を取れることである。type `Environment Variable` の値が入っていれば export は不要。
 
 ```bash
 gcloud auth application-default print-access-token >/dev/null
@@ -111,8 +130,9 @@ scripts/cursor-cloud/cursor-gcp-oidc | jq -r '.success'
 | 症状 | 見るところ |
 |---|---|
 | `jq is required` | Cloud Agent の PATH に `jq` が無いか |
-| `executables need to be explicitly allowed` | Secrets タブの `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
-| credential ファイルが無い | `start` に `setup-adc.sh` があるか。`CURSOR_WIF_PROJECT_NUMBER` が入っているか |
+| `executables need to be explicitly allowed` | Secrets の `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が type `Environment Variable` で `1` か |
+| credential ファイルが無い | `start` に `setup-adc.sh` があるか。`CURSOR_WIF_PROJECT_NUMBER` の type が `Environment Variable` か。`Build Secret` になっていないか |
+| 値が `[REDACTED]` になる | type が `Runtime Secret` になっていないか。この手順の値は `Environment Variable` |
 | STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
 | mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |
 | `OIDC socket not found` | `/run/cursor/api.sock`。Cursor 管理 VM 以外では無い |

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -2,11 +2,20 @@
 
 ## 概要
 
-Cloud Agent が Cursor の短命 OIDC JWT を GCP STS に渡し、federated token で data-dev datalake を読む。設計は [INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md)。WIF pool は #83。この文書は apply 後の Cursor 側配線である。
+達成したいのは、Cloud Agent が起動したあと、crawler や GCS クライアントが普通に data-dev datalake へ届くことである。鍵は置かない。人が token 交換を指示しない。ADC が mint と STS を行う。
 
-Cursor は IdP、GCP が検証する。ダッシュボードに WIF や issuer は登録しない。token 交換を毎回指示する必要はない。ADC が mint と STS を行う。mint の `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま使う。`allowed_audiences` が空なら GCP は canonical name を `https:` の有無どちらでも受理する（[仕様](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.providers#Oidc)）。
+起動時の動きは次のとおりである。
 
-ヘルパーは [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh)（`start` から credential JSON を書く）と [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc)（Google Auth が呼ぶ mint。`jq` と `curl` が要る）。
+1. Secrets が環境変数として入った状態で VM が上がる。
+2. `start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`GOOGLE_APPLICATION_CREDENTIALS` はそのパスを指す。
+3. GCS などに触ると Google Auth が JSON を読む。`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` なので [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) を起動する（`jq` と `curl` が要る）。
+4. ヘルパーが VM 内 socket から Cursor OIDC JWT を mint する（寿命 5 分）。`aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま。
+5. GCP STS が JWKS で検証し、`repo_url` と `agent_runtime == managed` を見る。federated token を返す。
+6. GCS は `principal://.../workloadIdentityPools/cursor/subject/<sub>` に付いた IAM だけで許す。
+
+この文書は、その流れになるよう Cursor 側を配線する手順である。設計は [INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md)。WIF pool は #83。Cursor は IdP、GCP が検証する。ダッシュボードに WIF や issuer は登録しない。`allowed_audiences` が空なら GCP は canonical name を `https:` の有無どちらでも受理する（[仕様](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.providers#Oidc)）。
+
+JSON を書くスクリプトは [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh) である。
 
 ## Cursor に設定するもの
 
@@ -45,8 +54,6 @@ Cursor は IdP、GCP が検証する。ダッシュボードに WIF や issuer �
 2. app-dev の `cursor_oidc_subjects` に、許可する Cursor `sub` を入れる。例: `["user:308716925"]`。`sub` はメールではない。空なら WIF は通っても GCS は拒否する。
 3. 上の「Cursor に設定するもの」を Secrets と Environment に入れる。
 4. 新しい Cloud Agent を起動する。`start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `cursor-gcp-oidc` の絶対パスである。
-
-起動後は Google Auth が JSON を読み、ヘルパーが JWT を mint し（寿命 5 分）、STS が `repo_url` と `agent_runtime == managed` を見る。GCS は `principal://.../workloadIdentityPools/cursor/subject/<sub>` の IAM だけで許す。
 
 ## 動作確認
 

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -6,6 +6,30 @@
 
 起動時の動きは次のとおりである。
 
+```mermaid
+sequenceDiagram
+  participant Secrets as Secrets
+  participant Start as start
+  participant Auth as Google Auth
+  participant Helper as cursor-gcp-oidc
+  participant Socket as Cursor OIDC
+  participant Sts as GCP STS
+  participant Gcs as datalake
+
+  Note over Secrets,Start: VM 起動。Secrets が環境変数として入る
+  Secrets->>Start: CURSOR_WIF_PROJECT_NUMBER など
+  Start->>Start: cursor-wif.json を書く
+  Note over Start: GOOGLE_APPLICATION_CREDENTIALS がそのパス
+  Auth->>Start: 初回の GCS 呼び出しで JSON を読む
+  Auth->>Helper: ALLOW_EXECUTABLES=1 なら起動
+  Helper->>Socket: JWT を mint
+  Socket-->>Helper: JWT 寿命 5 分
+  Helper-->>Auth: id_token
+  Auth->>Sts: JWT を交換
+  Sts-->>Auth: federated token
+  Auth->>Gcs: objectViewer / objectCreator
+```
+
 1. Secrets が環境変数として入った状態で VM が上がる。
 2. `start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`GOOGLE_APPLICATION_CREDENTIALS` はそのパスを指す。
 3. GCS などに触ると Google Auth が JSON を読む。`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` なので [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) を起動する（`jq` と `curl` が要る）。

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -8,24 +8,28 @@
 
 ```mermaid
 sequenceDiagram
-  participant Secrets as Secrets
-  participant Start as start
-  participant Auth as Google Auth
-  participant Helper as cursor-gcp-oidc
-  participant Socket as Cursor OIDC
-  participant Sts as GCP STS
-  participant Gcs as datalake
+  box Cloud Agent VM
+    participant Start as start
+    participant Auth as Google Auth
+    participant Helper as cursor-gcp-oidc
+    participant Socket as OIDC socket
+  end
+  box Cursor IdP
+    participant Cursor as api.cursor.com
+  end
+  box GCP
+    participant Sts as STS
+    participant Gcs as datalake
+  end
 
-  Note over Secrets,Start: VM 起動。Secrets が環境変数として入る
-  Secrets->>Start: CURSOR_WIF_PROJECT_NUMBER など
+  Note over Start,Socket: VM 起動。Secrets が環境変数として入る
   Start->>Start: cursor-wif.json を書く
-  Note over Start: GOOGLE_APPLICATION_CREDENTIALS がそのパス
-  Auth->>Start: 初回の GCS 呼び出しで JSON を読む
-  Auth->>Helper: ALLOW_EXECUTABLES=1 なら起動
+  Auth->>Helper: JSON を読みヘルパーを起動
   Helper->>Socket: JWT を mint
   Socket-->>Helper: JWT 寿命 5 分
   Helper-->>Auth: id_token
   Auth->>Sts: JWT を交換
+  Sts->>Cursor: JWKS で検証
   Sts-->>Auth: federated token
   Auth->>Gcs: objectViewer / objectCreator
 ```

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -49,20 +49,24 @@ JSON を書くスクリプトは [`scripts/cursor-cloud/setup-adc.sh`](../../scr
 
 ## Cursor に設定するもの
 
-入れる場所は [Cloud Agents](https://cursor.com/dashboard/cloud-agents) の Secrets と Environment。`CURSOR_WIF_PROJECT_NUMBER` は ops の terraform output `ops_project_number` である。秘密ではない。
+入れる場所は [Cloud Agents](https://cursor.com/dashboard/cloud-agents) の **Secrets タブ** と、Cloud Agent の **Environment**（install / `start` / ネットワークのマシン設定。プロセスの環境変数のことではない）。
 
-### Secrets
+Cloud Agents のダッシュボードには、環境変数専用の欄が無い。Secrets タブに書いた値が VM の環境変数になる。下の表はどれも秘密ではない。鍵の代わりにここに置くのではなく、専用欄が無いから Secrets タブを使う。
 
-| 名前 | 値 |
-|---|---|
-| `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` |
-| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） |
-| `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` |
-| `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` |
+`CURSOR_WIF_PROJECT_NUMBER` は ops の terraform output `ops_project_number` である。
 
-`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく、`start` が書く WIF credential config のパスである。
+### Secrets タブ（環境変数として渡る）
 
-### Environment
+| 名前 | 値 | 秘密か |
+|---|---|---|
+| `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` | いいえ |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） | いいえ。鍵ではなく `start` が書く JSON のパス |
+| `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` | いいえ |
+| `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` | いいえ。バケット名 |
+
+### Environment（Cloud Agent のマシン設定）
+
+ダッシュボードの Environment は「どの VM 設定で agent を起動するか」である。プロセスの環境変数一覧ではない。環境変数は上の Secrets タブから入る。
 
 | 項目 | 値 |
 |---|---|
@@ -82,12 +86,12 @@ JSON を書くスクリプトは [`scripts/cursor-cloud/setup-adc.sh`](../../scr
 
 1. ops を apply し、`ops_project_number` を控える。
 2. app-dev の `cursor_oidc_subjects` に、許可する Cursor `sub` を入れる。例: `["user:308716925"]`。`sub` はメールではない。空なら WIF は通っても GCS は拒否する。
-3. 上の「Cursor に設定するもの」を Secrets と Environment に入れる。
+3. 上の「Cursor に設定するもの」を入れる。環境変数は Secrets タブ。`start` とネットワークは Environment（マシン設定）。
 4. 新しい Cloud Agent を起動する。`start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `cursor-gcp-oidc` の絶対パスである。
 
 ## 動作確認
 
-WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本線は ADC が token を取れることである。Secrets が入っていれば export は不要。
+WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本線は ADC が token を取れることである。Secrets タブの値が入っていれば export は不要。
 
 ```bash
 gcloud auth application-default print-access-token >/dev/null
@@ -107,7 +111,7 @@ scripts/cursor-cloud/cursor-gcp-oidc | jq -r '.success'
 | 症状 | 見るところ |
 |---|---|
 | `jq is required` | Cloud Agent の PATH に `jq` が無いか |
-| `executables need to be explicitly allowed` | Secrets の `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
+| `executables need to be explicitly allowed` | Secrets タブの `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
 | credential ファイルが無い | `start` に `setup-adc.sh` があるか。`CURSOR_WIF_PROJECT_NUMBER` が入っているか |
 | STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
 | mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -26,6 +26,8 @@ sequenceDiagram
   Start->>Start: cursor-wif.json を書く
   Auth->>Helper: JSON を読みヘルパーを起動
   Helper->>Socket: JWT を mint
+  Socket->>Cursor: 署名を依頼
+  Cursor-->>Socket: JWT
   Socket-->>Helper: JWT 寿命 5 分
   Helper-->>Auth: id_token
   Auth->>Sts: JWT を交換

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -1,82 +1,83 @@
 # Cursor Cloud から GCP へ OIDC / WIF で接続する
 
-Cloud Agent が Cursor の短命 OIDC JWT を GCP STS に渡し、federated token で data-dev datalake を読む手順。設計は [INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md)。Terraform は #83。この文書は apply 後の Cursor 側配線である。
+## 概要
 
-Cursor は IdP で、GCP が検証する。WIF pool / provider / issuer を Cursor のダッシュボードに登録しない。
+Cloud Agent が Cursor の短命 OIDC JWT を GCP STS に渡し、federated token で data-dev datalake を読む。設計は [INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md)。WIF pool は #83。この文書は apply 後の Cursor 側配線である。
 
-## 置かないもの
+Cursor は IdP、GCP が検証する。ダッシュボードに WIF や issuer は登録しない。token 交換を毎回指示する必要はない。ADC が mint と STS を行う。mint の `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま使う。`allowed_audiences` が空なら GCP は canonical name を `https:` の有無どちらでも受理する（[仕様](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.providers#Oidc)）。
 
-- Service Account JSON キー
-- 人間ユーザーの Application Default Credentials
-- credential config の `service_account_impersonation_url`（`--service-account` 付きの `gcloud iam workload-identity-pools create-cred-config`）
-- `cursor_oidc_subjects`（app-dev の gitignore 済み `terraform.tfvars`）
+ヘルパーは [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh)（`start` から credential JSON を書く）と [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc)（Google Auth が呼ぶ mint。`jq` と `curl` が要る）。
 
-## Terraform から控える値
+## Cursor に設定するもの
 
-ops の `ops_project_number` を Cursor Secrets の `CURSOR_WIF_PROJECT_NUMBER` に入れる。秘密ではない。
+入れる場所は [Cloud Agents](https://cursor.com/dashboard/cloud-agents) の Secrets と Environment。`CURSOR_WIF_PROJECT_NUMBER` は ops の terraform output `ops_project_number` である。秘密ではない。
 
-app-dev の `cursor_oidc_subjects` に許可する Cursor `sub` を入れる。例: `["user:308716925"]`。空なら WIF は通っても GCS は拒否する。`sub` はメールではない。
-
-## Audience
-
-Google Auth は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` に次を渡す。`cursor-gcp-oidc` はそれを mint `aud` にそのまま使う。
-
-```text
-//iam.googleapis.com/projects/<number>/locations/global/workloadIdentityPools/cursor/providers/oidc
-```
-
-`allowed_audiences` が空のとき、GCP は canonical name を `https:` の有無どちらでも受理する。[仕様](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.providers#Oidc)。カスタム値だけを `allowed_audiences` に入れるとその自動受理は効かない。このリポジトリでは空のままにする。
-
-## Cursor Secrets
-
-[Cloud Agents の Secrets](https://cursor.com/dashboard/cloud-agents) に次を入れる。
+### Secrets
 
 | 名前 | 値 |
 |---|---|
 | `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` |
-| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは合わせる） |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） |
 | `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` |
 | `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` |
 
-`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく WIF credential config のパスである。
+`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく、`start` が書く WIF credential config のパスである。
 
-## Environment の `start`
+### Environment
 
-既存の install / snapshot は残す。`.cursor/environment.json` はリポジトリに置かない。start に次を足す。
+| 項目 | 値 |
+|---|---|
+| `start` | `scripts/cursor-cloud/setup-adc.sh` |
+| Network allowlist（egress を制限しているときだけ） | `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` |
 
-```bash
-scripts/cursor-cloud/setup-adc.sh
-```
+既存の install / snapshot は残す。リポジトリに `.cursor/environment.json` は置かない。`install` で export した変数は Build 後に残らない。mint 自体は VM 内の Unix socket で、allowlist は不要である。
 
-これは `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `scripts/cursor-cloud/cursor-gcp-oidc` の絶対パス。ADC の環境変数は Secrets が渡す。`install` で export しても Build 後に残らない。
+### 置かないもの
 
-egress を制限しているなら `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` を許可する。mint は VM 内 socket である。
+- Service Account JSON キー、人間ユーザーの ADC
+- WIF pool / provider / issuer（Cursor 側に登録する欄は無い）
+- `service_account_impersonation_url`（`gcloud ... create-cred-config` に `--service-account` を付けない）
+- `cursor_oidc_subjects`（Cursor ではなく app-dev の gitignore 済み `terraform.tfvars`）
 
-## 起動後に起きること
+## 手順
 
-1. Google Auth が `cursor-wif.json` を読む
-2. `cursor-gcp-oidc` が socket から JWT を mint する（寿命 5 分）
-3. STS が `repo_url` と `agent_runtime == managed` を見る
-4. GCS は `principal://.../workloadIdentityPools/cursor/subject/<sub>` の IAM だけで許す
+1. ops を apply し、`ops_project_number` を控える。
+2. app-dev の `cursor_oidc_subjects` に、許可する Cursor `sub` を入れる。例: `["user:308716925"]`。`sub` はメールではない。空なら WIF は通っても GCS は拒否する。
+3. 上の「Cursor に設定するもの」を Secrets と Environment に入れる。
+4. 新しい Cloud Agent を起動する。`start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `cursor-gcp-oidc` の絶対パスである。
 
-token 交換を手順として繰り返さない。ADC が mint と STS を行う。
+起動後は Google Auth が JSON を読み、ヘルパーが JWT を mint し（寿命 5 分）、STS が `repo_url` と `agent_runtime == managed` を見る。GCS は `principal://.../workloadIdentityPools/cursor/subject/<sub>` の IAM だけで許す。
 
 ## 動作確認
 
-WIF と allowlist の apply が済んでいる前提。
+WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本線は ADC が token を取れることである。Secrets が入っていれば export は不要。
+
+```bash
+gcloud auth application-default print-access-token >/dev/null
+```
+
+mint ヘルパーだけを試すときは audience を渡す。値は付け替えない。
 
 ```bash
 export GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE="//iam.googleapis.com/projects/${CURSOR_WIF_PROJECT_NUMBER}/locations/global/workloadIdentityPools/cursor/providers/oidc"
 scripts/cursor-cloud/cursor-gcp-oidc | jq -r '.success'
-
-export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.config/gcloud/cursor-wif.json"
-export GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1
-gcloud auth application-default print-access-token >/dev/null
 ```
 
-## 手元で credential JSON を書く場合
+ヘルパーのテストは `python3 scripts/cursor-cloud/tests/test_scripts.py`。
 
-`--service-account` は付けない。
+## うまくいかないとき
+
+| 症状 | 見るところ |
+|---|---|
+| `jq is required` | Cloud Agent の PATH に `jq` が無いか |
+| `executables need to be explicitly allowed` | Secrets の `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
+| credential ファイルが無い | `start` に `setup-adc.sh` があるか。`CURSOR_WIF_PROJECT_NUMBER` が入っているか |
+| STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
+| mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |
+| `OIDC socket not found` | `/run/cursor/api.sock`。Cursor 管理 VM 以外では無い |
+| credential JSON に `service_account_impersonation_url` がある | `--service-account` を付けて生成している。Cloud Agent では `setup-adc.sh` を使う |
+
+JSON を手元で書くときも `--service-account` は付けない。
 
 ```bash
 gcloud iam workload-identity-pools create-cred-config \
@@ -85,27 +86,3 @@ gcloud iam workload-identity-pools create-cred-config \
   --executable-command="$(pwd)/scripts/cursor-cloud/cursor-gcp-oidc" \
   --output-file="${HOME}/.config/gcloud/cursor-wif.json"
 ```
-
-Cloud Agent では `setup-adc.sh` が同じ JSON を書く。
-
-## スクリプト
-
-| ファイル | 役割 |
-|---|---|
-| [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) | Google Auth が呼ぶ mint ヘルパー |
-| [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh) | `start` から呼び JSON を書く |
-
-```bash
-python3 scripts/cursor-cloud/tests/test_scripts.py
-```
-
-## うまくいかないとき
-
-| 症状 | 見るところ |
-|---|---|
-| `jq is required` | Cloud Agent の PATH に `jq` が無いか |
-| `executables need to be explicitly allowed` | `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
-| STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
-| mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |
-| `OIDC socket not found` | `/run/cursor/api.sock`。Cursor 管理 VM 以外では無い |
-| credential JSON に `service_account_impersonation_url` がある | `--service-account` を付けて生成している |

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -67,7 +67,7 @@ WIF と allowlist の apply が済んでいる前提。
 
 ```bash
 export GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE="//iam.googleapis.com/projects/${CURSOR_WIF_PROJECT_NUMBER}/locations/global/workloadIdentityPools/cursor/providers/oidc"
-scripts/cursor-cloud/cursor-gcp-oidc | python3 -c 'import json,sys; print(json.load(sys.stdin)["success"])'
+scripts/cursor-cloud/cursor-gcp-oidc | jq -r '.success'
 
 export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.config/gcloud/cursor-wif.json"
 export GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1
@@ -103,6 +103,7 @@ python3 scripts/cursor-cloud/tests/test_scripts.py
 
 | 症状 | 見るところ |
 |---|---|
+| `jq is required` | Cloud Agent の PATH に `jq` が無いか |
 | `executables need to be explicitly allowed` | `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
 | STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
 | mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -1,0 +1,110 @@
+# Cursor Cloud から GCP へ OIDC / WIF で接続する
+
+Cloud Agent が Cursor の短命 OIDC JWT を GCP STS に渡し、federated token で data-dev datalake を読む手順。設計は [INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md)。Terraform は #83。この文書は apply 後の Cursor 側配線である。
+
+Cursor は IdP で、GCP が検証する。WIF pool / provider / issuer を Cursor のダッシュボードに登録しない。
+
+## 置かないもの
+
+- Service Account JSON キー
+- 人間ユーザーの Application Default Credentials
+- credential config の `service_account_impersonation_url`（`--service-account` 付きの `gcloud iam workload-identity-pools create-cred-config`）
+- `cursor_oidc_subjects`（app-dev の gitignore 済み `terraform.tfvars`）
+
+## Terraform から控える値
+
+ops の `ops_project_number` を Cursor Secrets の `CURSOR_WIF_PROJECT_NUMBER` に入れる。秘密ではない。
+
+app-dev の `cursor_oidc_subjects` に許可する Cursor `sub` を入れる。例: `["user:308716925"]`。空なら WIF は通っても GCS は拒否する。`sub` はメールではない。
+
+## Audience
+
+Google Auth は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` に次を渡す。`cursor-gcp-oidc` はそれを mint `aud` にそのまま使う。
+
+```text
+//iam.googleapis.com/projects/<number>/locations/global/workloadIdentityPools/cursor/providers/oidc
+```
+
+`allowed_audiences` が空のとき、GCP は canonical name を `https:` の有無どちらでも受理する。[仕様](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.providers#Oidc)。カスタム値だけを `allowed_audiences` に入れるとその自動受理は効かない。このリポジトリでは空のままにする。
+
+## Cursor Secrets
+
+[Cloud Agents の Secrets](https://cursor.com/dashboard/cloud-agents) に次を入れる。
+
+| 名前 | 値 |
+|---|---|
+| `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは合わせる） |
+| `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` |
+| `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` |
+
+`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく WIF credential config のパスである。
+
+## Environment の `start`
+
+既存の install / snapshot は残す。`.cursor/environment.json` はリポジトリに置かない。start に次を足す。
+
+```bash
+scripts/cursor-cloud/setup-adc.sh
+```
+
+これは `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `scripts/cursor-cloud/cursor-gcp-oidc` の絶対パス。ADC の環境変数は Secrets が渡す。`install` で export しても Build 後に残らない。
+
+egress を制限しているなら `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` を許可する。mint は VM 内 socket である。
+
+## 起動後に起きること
+
+1. Google Auth が `cursor-wif.json` を読む
+2. `cursor-gcp-oidc` が socket から JWT を mint する（寿命 5 分）
+3. STS が `repo_url` と `agent_runtime == managed` を見る
+4. GCS は `principal://.../workloadIdentityPools/cursor/subject/<sub>` の IAM だけで許す
+
+token 交換を手順として繰り返さない。ADC が mint と STS を行う。
+
+## 動作確認
+
+WIF と allowlist の apply が済んでいる前提。
+
+```bash
+export GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE="//iam.googleapis.com/projects/${CURSOR_WIF_PROJECT_NUMBER}/locations/global/workloadIdentityPools/cursor/providers/oidc"
+scripts/cursor-cloud/cursor-gcp-oidc | python3 -c 'import json,sys; print(json.load(sys.stdin)["success"])'
+
+export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.config/gcloud/cursor-wif.json"
+export GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1
+gcloud auth application-default print-access-token >/dev/null
+```
+
+## 手元で credential JSON を書く場合
+
+`--service-account` は付けない。
+
+```bash
+gcloud iam workload-identity-pools create-cred-config \
+  "projects/${CURSOR_WIF_PROJECT_NUMBER}/locations/global/workloadIdentityPools/cursor/providers/oidc" \
+  --subject-token-type=urn:ietf:params:oauth:token-type:id_token \
+  --executable-command="$(pwd)/scripts/cursor-cloud/cursor-gcp-oidc" \
+  --output-file="${HOME}/.config/gcloud/cursor-wif.json"
+```
+
+Cloud Agent では `setup-adc.sh` が同じ JSON を書く。
+
+## スクリプト
+
+| ファイル | 役割 |
+|---|---|
+| [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) | Google Auth が呼ぶ mint ヘルパー |
+| [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh) | `start` から呼び JSON を書く |
+
+```bash
+python3 scripts/cursor-cloud/tests/test_scripts.py
+```
+
+## うまくいかないとき
+
+| 症状 | 見るところ |
+|---|---|
+| `executables need to be explicitly allowed` | `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が `1` か |
+| STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
+| mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |
+| `OIDC socket not found` | `/run/cursor/api.sock`。Cursor 管理 VM 以外では無い |
+| credential JSON に `service_account_impersonation_url` がある | `--service-account` を付けて生成している |

--- a/scripts/cursor-cloud/cursor-gcp-oidc
+++ b/scripts/cursor-cloud/cursor-gcp-oidc
@@ -3,24 +3,20 @@ set -euo pipefail
 
 # Google Auth executable helper. Mints a Cursor OIDC JWT with
 # GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE as aud and prints the JSON the auth
-# libraries expect on stdout.
+# libraries expect on stdout. JSON is handled with jq so the helper does
+# not depend on a particular python3 version.
 
 fail() {
   local code="$1"
   local message="$2"
-  python3 -c 'import json, sys
-print(json.dumps({
-    "version": 1,
-    "success": False,
-    "code": sys.argv[1],
-    "message": sys.argv[2],
-}))' "${code}" "${message}"
+  jq -n --arg code "${code}" --arg message "${message}" \
+    '{version: 1, success: false, code: $code, message: $message}'
   printf '%s\n' "${message}" >&2
   exit 1
 }
 
-if ! command -v python3 >/dev/null 2>&1; then
-  printf 'python3 is required\n' >&2
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'jq is required\n' >&2
   exit 1
 fi
 if ! command -v curl >/dev/null 2>&1; then
@@ -37,7 +33,7 @@ if [[ ! -S "${socket}" ]]; then
   fail "401" "Cursor OIDC socket not found: ${socket}"
 fi
 
-payload="$(python3 -c 'import json, sys; print(json.dumps({"aud": sys.argv[1]}))' "${mint_audience}")"
+payload="$(jq -n --arg aud "${mint_audience}" '{aud: $aud}')"
 
 set +e
 response="$(
@@ -52,40 +48,17 @@ if [[ "${curl_status}" -ne 0 ]]; then
   fail "502" "Cursor OIDC mint failed (curl exit ${curl_status})"
 fi
 
-token_type="${GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE:-urn:ietf:params:oauth:token-type:id_token}"
+token="$(printf '%s' "${response}" | jq -er '.token')" || fail "502" "Cursor OIDC mint response missing token or expires_at"
+expires_at="$(printf '%s' "${response}" | jq -er '.expires_at')" || fail "502" "Cursor OIDC mint response missing token or expires_at"
 
-python3 - "${response}" "${token_type}" <<'PY'
-import json
-import sys
-
-raw_response, token_type = sys.argv[1], sys.argv[2]
-try:
-    body = json.loads(raw_response)
-except json.JSONDecodeError as exc:
-    print(json.dumps({
-        "version": 1,
-        "success": False,
-        "code": "502",
-        "message": f"Cursor OIDC mint returned non-JSON: {exc}",
-    }))
-    sys.exit(1)
-
-token = body.get("token")
-expires_at = body.get("expires_at")
-if not token or expires_at is None:
-    print(json.dumps({
-        "version": 1,
-        "success": False,
-        "code": "502",
-        "message": "Cursor OIDC mint response missing token or expires_at",
-    }))
-    sys.exit(1)
-
-print(json.dumps({
-    "version": 1,
-    "success": True,
-    "token_type": token_type,
-    "id_token": token,
-    "expiration_time": int(expires_at),
-}))
-PY
+jq -n \
+  --arg token "${token}" \
+  --arg token_type "${GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE:-urn:ietf:params:oauth:token-type:id_token}" \
+  --argjson expiration_time "${expires_at}" \
+  '{
+    version: 1,
+    success: true,
+    token_type: $token_type,
+    id_token: $token,
+    expiration_time: $expiration_time
+  }'

--- a/scripts/cursor-cloud/cursor-gcp-oidc
+++ b/scripts/cursor-cloud/cursor-gcp-oidc
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Google Auth executable helper. Mints a Cursor OIDC JWT with
+# GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE as aud and prints the JSON the auth
+# libraries expect on stdout.
+
+fail() {
+  local code="$1"
+  local message="$2"
+  python3 -c 'import json, sys
+print(json.dumps({
+    "version": 1,
+    "success": False,
+    "code": sys.argv[1],
+    "message": sys.argv[2],
+}))' "${code}" "${message}"
+  printf '%s\n' "${message}" >&2
+  exit 1
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'python3 is required\n' >&2
+  exit 1
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  fail "400" "curl is required to mint a Cursor OIDC token"
+fi
+
+mint_audience="${GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE:-}"
+if [[ -z "${mint_audience}" ]]; then
+  fail "400" "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE is not set"
+fi
+
+socket="${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
+if [[ ! -S "${socket}" ]]; then
+  fail "401" "Cursor OIDC socket not found: ${socket}"
+fi
+
+payload="$(python3 -c 'import json, sys; print(json.dumps({"aud": sys.argv[1]}))' "${mint_audience}")"
+
+set +e
+response="$(
+  curl -sS --fail --unix-socket "${socket}" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}" \
+    http://cursor-agent/v1/tokens/oidc
+)"
+curl_status=$?
+set -e
+if [[ "${curl_status}" -ne 0 ]]; then
+  fail "502" "Cursor OIDC mint failed (curl exit ${curl_status})"
+fi
+
+token_type="${GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE:-urn:ietf:params:oauth:token-type:id_token}"
+
+python3 - "${response}" "${token_type}" <<'PY'
+import json
+import sys
+
+raw_response, token_type = sys.argv[1], sys.argv[2]
+try:
+    body = json.loads(raw_response)
+except json.JSONDecodeError as exc:
+    print(json.dumps({
+        "version": 1,
+        "success": False,
+        "code": "502",
+        "message": f"Cursor OIDC mint returned non-JSON: {exc}",
+    }))
+    sys.exit(1)
+
+token = body.get("token")
+expires_at = body.get("expires_at")
+if not token or expires_at is None:
+    print(json.dumps({
+        "version": 1,
+        "success": False,
+        "code": "502",
+        "message": "Cursor OIDC mint response missing token or expires_at",
+    }))
+    sys.exit(1)
+
+print(json.dumps({
+    "version": 1,
+    "success": True,
+    "token_type": token_type,
+    "id_token": token,
+    "expiration_time": int(expires_at),
+}))
+PY

--- a/scripts/cursor-cloud/setup-adc.sh
+++ b/scripts/cursor-cloud/setup-adc.sh
@@ -24,35 +24,21 @@ fi
 
 audience="//iam.googleapis.com/projects/${project_number}/locations/global/workloadIdentityPools/cursor/providers/oidc"
 
-python3 - "${audience}" "${mint}" "${config_path}" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-audience, executable, output = sys.argv[1], sys.argv[2], sys.argv[3]
-path = Path(output)
-path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(
-    json.dumps(
-        {
-            "type": "external_account",
-            "audience": audience,
-            "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
-            "token_url": "https://sts.googleapis.com/v1/token",
-            "universe_domain": "googleapis.com",
-            "credential_source": {
-                "executable": {
-                    "command": executable,
-                    "timeout_millis": 10000,
-                }
-            },
-        },
-        indent=2,
-    )
-    + "\n",
-    encoding="utf-8",
-)
-print(f"wrote {path}", file=sys.stderr)
-PY
+mkdir -p "$(dirname "${config_path}")"
+cat >"${config_path}" <<EOF
+{
+  "type": "external_account",
+  "audience": "${audience}",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "universe_domain": "googleapis.com",
+  "credential_source": {
+    "executable": {
+      "command": "${mint}",
+      "timeout_millis": 10000
+    }
+  }
+}
+EOF
 
 printf 'ADC config: %s\n' "${config_path}"

--- a/scripts/cursor-cloud/setup-adc.sh
+++ b/scripts/cursor-cloud/setup-adc.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Write the WIF credential config for Cursor Cloud ADC. Env vars for ADC
-# come from Cursor Secrets, not from this script.
+# Write the WIF credential config for Cursor Cloud ADC.
+# CURSOR_WIF_PROJECT_NUMBER comes from a Cursor Secret whose type is
+# Environment Variable, not Runtime Secret or Build Secret.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 project_number="${CURSOR_WIF_PROJECT_NUMBER:-}"

--- a/scripts/cursor-cloud/setup-adc.sh
+++ b/scripts/cursor-cloud/setup-adc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Write the WIF credential config for Cursor Cloud ADC. Env vars for ADC
+# come from Cursor Secrets, not from this script.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_number="${CURSOR_WIF_PROJECT_NUMBER:-}"
+mint="${SCRIPT_DIR}/cursor-gcp-oidc"
+config_path="${HOME}/.config/gcloud/cursor-wif.json"
+
+if [[ -z "${project_number}" ]]; then
+  printf 'CURSOR_WIF_PROJECT_NUMBER is not set (ops terraform output ops_project_number)\n' >&2
+  exit 1
+fi
+if [[ ! "${project_number}" =~ ^[0-9]+$ ]]; then
+  printf 'CURSOR_WIF_PROJECT_NUMBER must be digits, got: %s\n' "${project_number}" >&2
+  exit 1
+fi
+if [[ ! -x "${mint}" ]]; then
+  printf 'mint helper is not executable: %s\n' "${mint}" >&2
+  exit 1
+fi
+
+audience="//iam.googleapis.com/projects/${project_number}/locations/global/workloadIdentityPools/cursor/providers/oidc"
+
+python3 - "${audience}" "${mint}" "${config_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+audience, executable, output = sys.argv[1], sys.argv[2], sys.argv[3]
+path = Path(output)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(
+    json.dumps(
+        {
+            "type": "external_account",
+            "audience": audience,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+            "token_url": "https://sts.googleapis.com/v1/token",
+            "universe_domain": "googleapis.com",
+            "credential_source": {
+                "executable": {
+                    "command": executable,
+                    "timeout_millis": 10000,
+                }
+            },
+        },
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+print(f"wrote {path}", file=sys.stderr)
+PY
+
+printf 'ADC config: %s\n' "${config_path}"

--- a/scripts/cursor-cloud/tests/test_scripts.py
+++ b/scripts/cursor-cloud/tests/test_scripts.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Checks for Cursor Cloud WIF helpers. Stdlib only."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MINT = ROOT / "cursor-gcp-oidc"
+SETUP = ROOT / "setup-adc.sh"
+AUDIENCE = (
+    "//iam.googleapis.com/projects/123456789012/locations/global/"
+    "workloadIdentityPools/cursor/providers/oidc"
+)
+
+
+def run(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return subprocess.run(args, text=True, capture_output=True, env=merged)
+
+
+class HelpersTest(unittest.TestCase):
+    _sockets: list[socket.socket] = []
+
+    def test_setup_adc_writes_direct_access_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            result = run(
+                [str(SETUP)],
+                {"HOME": str(home), "CURSOR_WIF_PROJECT_NUMBER": "123456789012"},
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            config = json.loads(
+                (home / ".config/gcloud/cursor-wif.json").read_text()
+            )
+            self.assertNotIn("service_account_impersonation_url", config)
+            self.assertEqual(config["audience"], AUDIENCE)
+            self.assertEqual(
+                config["credential_source"]["executable"]["command"], str(MINT)
+            )
+
+    def test_mint_forwards_audience(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            socket_path = tmp_path / "api.sock"
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(str(socket_path))
+            self._sockets.append(server)
+            stub_dir = tmp_path / "bin"
+            stub_dir.mkdir()
+            fixture = tmp_path / "mint.json"
+            request_log = tmp_path / "request.json"
+            fixture.write_text(
+                json.dumps({"token": "header.payload.sig", "expires_at": 1_700_000_000})
+                + "\n"
+            )
+            stub = stub_dir / "curl"
+            stub.write_text(
+                f"""#!/usr/bin/env bash
+set -euo pipefail
+payload=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d) payload="$2"; shift 2 ;;
+    --unix-socket|-H) shift 2 ;;
+    --fail|-sS|-s) shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\\n' "${{payload}}" > {request_log.as_posix()!r}
+cat {fixture.as_posix()!r}
+"""
+            )
+            stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+            result = run(
+                [str(MINT)],
+                {
+                    "PATH": f"{stub_dir}:{os.environ['PATH']}",
+                    "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE": AUDIENCE,
+                    "CURSOR_AGENT_SOCKET": str(socket_path),
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            body = json.loads(result.stdout)
+            self.assertEqual(body["id_token"], "header.payload.sig")
+            self.assertEqual(json.loads(request_log.read_text())["aud"], AUDIENCE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

Cursor Cloud から GCP へ、SA キーなしで ADC する。mint ヘルパー 1 本（`jq` + `curl`）と `start` が credential JSON を書き、手順は runbook。WIF 本体は #83。この PR は apply しない。

## 読み順

1. **mint** — `scripts/cursor-cloud/cursor-gcp-oidc`（`jq` で JSON を扱う。`aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま）
2. **start** — `scripts/cursor-cloud/setup-adc.sh`（heredoc で `$HOME/.config/gcloud/cursor-wif.json` を書く。impersonation URL なし）
3. **手順** — `docs/runbooks/cursor-cloud-oidc-wif.md`

スキップ可: `scripts/cursor-cloud/tests/test_scripts.py`、`AGENTS.md`、ADR Next Step のリンク 1 行。

## 概要

Cloud Agent が Cursor OIDC JWT を GCP STS に渡し、federated token で datalake を読むためのクライアント配線。AWS の `CURSOR_AWS_ASSUME_IAM_ROLE_ARN` に相当する GCP フィールドは無いので、ヘルパーと runbook で組む。

## Why

INFRA-ADR-014 Next Step 3。#83 で ops の WIF と app-dev の `principal://` IAM は定義済み。残っていたのは mint / ADC / Cursor ダッシュボード手順。

## 関連 Issue

- Follows #83
- INFRA-ADR-014 Next Step 3

## 変更内容

- `cursor-gcp-oidc`: socket から JWT を mint する。JSON は `jq`。audience は付け替えない
- `setup-adc.sh`: credential JSON を heredoc で書く。`--service-account` 相当のフィールドは入れない
- runbook: Secrets は type を選ぶ。WIF 用の値は `Environment Variable`。`Runtime Secret` / `Build Secret` にはしない。保存済み Environment は VM の `install` / `start` / ネットワーク
- `.cursor/environment.json` は置かない

## 影響範囲

- GCP は変わらない（apply なし）
- ユーザー向けアプリ挙動: なし
- Cloud Agent は type `Environment Variable` の Secrets と Environment の `start` を足したあとに ADC が効く。mint には `jq` と `curl` が必要

## 確認方法

- `python3 scripts/cursor-cloud/tests/test_scripts.py -v`
- この Cloud Agent 上で live mint: JWT `aud` が `//iam.googleapis.com/...`

STS / GCS は ops → app-dev の apply 前なので未実施。

## レビュー観点

- mint が `aud` を書き換えないか
- JSON に `service_account_impersonation_url` が無いか
- Cloud Agent の python3 バージョンに依存していないか
- Secrets の type が公式の `Environment Variable` / `Runtime Secret` / `Build Secret` に沿っているか

## 補足

`allowed_audiences` にカスタム値だけを入れると `//` / `https:` の自動受理は効かない。このリポジトリでは空のまま。

Secrets の type は [Secrets & Network](https://cursor.com/docs/cloud-agent/security-network) を正とする。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a547679-75e1-4c93-8664-28b0e47545e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a547679-75e1-4c93-8664-28b0e47545e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

