### PR TITLE
refactor(terraform): terraform_remote_state の data label を data_dev に変更

### DIFF
--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -32,7 +32,7 @@ data "terraform_remote_state" "ops" {
 }
 
 # data 環境の Terraform state から、data 環境で作成したリソースの情報を参照するための data source
-data "terraform_remote_state" "data" {
+data "terraform_remote_state" "data_dev" {
   backend = "gcs"
 
   config = {
@@ -90,7 +90,7 @@ resource "google_artifact_registry_repository_iam_member" "cloud_run_service_age
 resource "google_storage_bucket_iam_member" "crawler" {
   for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
 
-  bucket = data.terraform_remote_state.data.outputs.datalake_bucket_name
+  bucket = data.terraform_remote_state.data_dev.outputs.datalake_bucket_name
   role   = each.value
   member = module.service_accounts.members["crawler"]
 }
@@ -126,11 +126,11 @@ resource "google_cloud_run_v2_job" "crawler" {
         }
         env {
           name  = "DATA_LAKE_PROJECT_ID"
-          value = data.terraform_remote_state.data.outputs.datalake_project_id
+          value = data.terraform_remote_state.data_dev.outputs.datalake_project_id
         }
         env {
           name  = "DATA_LAKE_BUCKET_NAME"
-          value = data.terraform_remote_state.data.outputs.datalake_bucket_name
+          value = data.terraform_remote_state.data_dev.outputs.datalake_bucket_name
         }
         env {
           name  = "LOG_LEVEL"

--- a/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
+++ b/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
@@ -12,7 +12,7 @@ override_data {
 }
 
 override_data {
-  target = data.terraform_remote_state.data
+  target = data.terraform_remote_state.data_dev
   values = {
     outputs = {
       datalake_bucket_name = "mock-datalake-bucket"

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -39,7 +39,7 @@ data "google_project" "project" {
 }
 
 # data-dev の datalake は箱。識別子だけ借りる。ops は identity かつ下流なので guest IAM はここ（INFRA-ADR-015）
-data "terraform_remote_state" "data" {
+data "terraform_remote_state" "data_dev" {
   backend = "gcs"
 
   config = {
@@ -94,11 +94,14 @@ module "cursor_wif" {
 resource "google_storage_bucket_iam_member" "cursor_oidc" {
   for_each = local.cursor_oidc_datalake_bindings
 
-  bucket = data.terraform_remote_state.data.outputs.datalake_bucket_name
+  bucket = data.terraform_remote_state.data_dev.outputs.datalake_bucket_name
   role   = each.value.role
   member = "${local.cursor_wif_subject_prefix}/${each.value.subject}"
 }
 
+# GitHub Actions の CI/CD 用サービスアカウントを作成し、ops 環境の Artifact Registry
+# （crawler イメージ置き場）へイメージを push できるよう roles/artifactregistry.writer を付与。
+# service_account_users で指定されたユーザーがこの SA を借用（actAs）できる。
 module "service_accounts" {
   source = "../../modules/service_accounts"
 

--- a/infra/terraform/environments/devgist-ops/tests/cursor_oidc.tftest.hcl
+++ b/infra/terraform/environments/devgist-ops/tests/cursor_oidc.tftest.hcl
@@ -10,7 +10,7 @@ override_data {
 }
 
 override_data {
-  target = data.terraform_remote_state.data
+  target = data.terraform_remote_state.data_dev
   values = {
     outputs = {
       datalake_bucket_name = "mock-datalake-bucket"


### PR DESCRIPTION
## 概要

- `devgist-ops` と `devgist-app/dev` の `data "terraform_remote_state"` の label を `data` → `data_dev` に変更（data-dev 環境の state 参照であることを明確化）
- `devgist-ops` の `module "service_accounts"` に目的の説明コメントを追加

## 検証

- `devgist-ops`: `terraform plan` → `2 to add`（tfvars に追加した `cursor_oidc_subjects` による IAM 付与のみ。label 変更自体は差分なし）
- `devgist-app/dev`: `terraform plan` → `No changes`

data source は read-only 参照のため label 変更による state への影響・作り直しはありません。