### PR TITLE
docs: gcloud CLI 用に CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE を runbook へ追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,4 @@ ADR の判断基準、相談の境界、記録ルールなどの詳細は skill 
 
 ## Cursor Cloud specific instructions
 
-GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON キーもユーザー ADC も置かない。credential config に `service_account_impersonation_url` を入れない。
-
-手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
-
-- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
-- 保存済み Environment は VM の `install` / `start` / ネットワークである。Secret の type `Environment Variable` とは別物。`start` は `scripts/cursor-cloud/setup-adc.sh`
-- mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
-- GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う
-- datalake のバケット名は `DATA_LAKE_BUCKET_NAME`。IAM の allowlist は ops の Terraform 変数 `cursor_oidc_subjects`
+GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON キーもユーザー ADC も置かない。credential config に `service_account_impersonation_url` を入れない。GCS や crawler では token 交換を手順として繰り返さない。ADC が mint と STS を行う。datalake のバケット名は `DATA_LAKE_BUCKET_NAME`。手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON �
 
 手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
 
-- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`（`GOOGLE_APPLICATION_CREDENTIALS` と同じパス）、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
+- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
 - 保存済み Environment は VM の `install` / `start` / ネットワークである。Secret の type `Environment Variable` とは別物。`start` は `scripts/cursor-cloud/setup-adc.sh`
 - mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
 - GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ GCP へのアクセスは Cursor OIDC と WIF を使う。Service Account JSON �
 
 手順の正本は [`docs/runbooks/cursor-cloud-oidc-wif.md`](docs/runbooks/cursor-cloud-oidc-wif.md)。ヘルパーは [`scripts/cursor-cloud/`](scripts/cursor-cloud/)。
 
-- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
+- WIF 用の値は Secrets に type `Environment Variable` で置く。`Runtime Secret` にも `Build Secret` にもしない。`CURSOR_WIF_PROJECT_NUMBER`、`GOOGLE_APPLICATION_CREDENTIALS`、`CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`（`GOOGLE_APPLICATION_CREDENTIALS` と同じパス）、`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`
 - 保存済み Environment は VM の `install` / `start` / ネットワークである。Secret の type `Environment Variable` とは別物。`start` は `scripts/cursor-cloud/setup-adc.sh`
 - mint の JWT `aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` をそのまま使う。`allowed_audiences` が空なら `//iam.googleapis.com/...` と `https://iam.googleapis.com/...` のどちらも GCP が受理する
 - GCS クライアントや crawler を動かすとき、token 交換を手順として繰り返さない。ADC が mint と STS を行う

--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -37,7 +37,7 @@ sequenceDiagram
 ```
 
 1. type `Environment Variable` の Secrets がプロセス環境変数として入った状態で VM が上がる。
-2. `start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`GOOGLE_APPLICATION_CREDENTIALS` はそのパスを指す。
+2. `start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`GOOGLE_APPLICATION_CREDENTIALS` と `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` はそのパスを指す。ADC は前者、`gcloud storage` などは後者を見る。
 3. GCS などに触ると Google Auth が JSON を読む。`GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` なので [`scripts/cursor-cloud/cursor-gcp-oidc`](../../scripts/cursor-cloud/cursor-gcp-oidc) を起動する（`jq` と `curl` が要る）。
 4. ヘルパーが VM 内 socket から Cursor OIDC JWT を mint する（寿命 5 分）。`aud` は `GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE` のまま。
 5. GCP STS が JWKS で検証し、`repo_url` と `agent_runtime == managed` を見る。federated token を返す。
@@ -53,7 +53,7 @@ JSON を書くスクリプトは [`scripts/cursor-cloud/setup-adc.sh`](../../scr
 
 | ダッシュボードの名前 | 何か | この手順で触るもの |
 |---|---|---|
-| Secrets | 名前と値の組。type を選ぶ | type `Environment Variable` の 4 件 |
+| Secrets | 名前と値の組。type を選ぶ | type `Environment Variable` の 5 件 |
 | Environment | Cloud Agent のマシン設定（`install` / `start` / ネットワーク） | `start` と、egress を制限しているときの allowlist |
 
 Secrets の type は [Secrets & Network](https://cursor.com/docs/cloud-agent/security-network) の定義に従う。
@@ -76,10 +76,11 @@ Secrets の type は [Secrets & Network](https://cursor.com/docs/cloud-agent/sec
 |---|---|
 | `CURSOR_WIF_PROJECT_NUMBER` | ops の `ops_project_number` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`$HOME` が違うときは `echo $HOME` で合わせる） |
+| `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` | `/home/ubuntu/.config/gcloud/cursor-wif.json`（`GOOGLE_APPLICATION_CREDENTIALS` と同じ。`gcloud storage` など gcloud CLI が ADC を見ないため） |
 | `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` | `1` |
 | `DATA_LAKE_BUCKET_NAME` | crawler を動かすなら `haru256-devgist-data-dev-datalake` |
 
-`GOOGLE_APPLICATION_CREDENTIALS` は鍵ではなく、`start` が書く JSON のパスである。
+`GOOGLE_APPLICATION_CREDENTIALS` と `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` は鍵ではなく、`start` が書く JSON のパスである。Python の GCS クライアントは前者、`gcloud storage ls` は後者を使う。JSON 本体を Secret に置かない。
 
 type を `Runtime Secret` にすると、agent は値を `[REDACTED]` としか見えない。プロジェクト番号やパスの確認ができなくなる。type を `Build Secret` にすると、`start` も Google Auth も読めない。
 
@@ -105,7 +106,7 @@ type を `Runtime Secret` にすると、agent は値を `[REDACTED]` としか�
 
 1. data-dev を apply し、datalake 箱を先に作る。
 2. ops を apply し、`ops_project_number` を控える。gitignore 済み `terraform.tfvars` の `cursor_oidc_subjects` に、許可する Cursor `sub` を入れる。例: `["user:308716925"]`。`sub` はメールではない。空なら WIF は通っても GCS は拒否する。Cloud Run Job 起動はこの identity に含めない。付けるときは app が書く（[INFRA-ADR-015](../adr/infra/015-guest-iam-downstream.md)）。
-3. Secrets に上の 4 件を type `Environment Variable` で入れる。Environment の `start` に `setup-adc.sh` を入れる。egress を制限しているなら GCP ホストを Environment の allowlist に足す。
+3. Secrets に上の 5 件を type `Environment Variable` で入れる。Environment の `start` に `setup-adc.sh` を入れる。egress を制限しているなら GCP ホストを Environment の allowlist に足す。
 4. 新しい Cloud Agent を起動する。`start` が `$HOME/.config/gcloud/cursor-wif.json` を書く。`command` は checkout した `cursor-gcp-oidc` の絶対パスである。
 
 ## 動作確認
@@ -114,7 +115,10 @@ WIF と allowlist の apply、Cursor の設定、`start` 済みが前提。本�
 
 ```bash
 gcloud auth application-default print-access-token >/dev/null
+gcloud storage ls "gs://${DATA_LAKE_BUCKET_NAME:-haru256-devgist-data-dev-datalake}"
 ```
+
+`gcloud storage` は ADC を見ない。`CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` が無いと `You do not currently have an active account selected` になる。
 
 mint ヘルパーだけを試すときは audience を渡す。値は付け替えない。
 
@@ -132,6 +136,7 @@ scripts/cursor-cloud/cursor-gcp-oidc | jq -r '.success'
 | `jq is required` | Cloud Agent の PATH に `jq` が無いか |
 | `executables need to be explicitly allowed` | Secrets の `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` が type `Environment Variable` で `1` か |
 | credential ファイルが無い | `start` に `setup-adc.sh` があるか。`CURSOR_WIF_PROJECT_NUMBER` の type が `Environment Variable` か。`Build Secret` になっていないか |
+| `You do not currently have an active account selected` | Secrets の `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` が `GOOGLE_APPLICATION_CREDENTIALS` と同じパスか。type が `Environment Variable` か |
 | 値が `[REDACTED]` になる | type が `Runtime Secret` になっていないか。この手順の値は `Environment Variable` |
 | STS が audience 不一致 | JWT `aud` が canonical name か。`allowed_audiences` にカスタム値だけを入れてないか |
 | mint は成功、GCS が 403 | `cursor_oidc_subjects` と JWT `sub` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Cloud Agent から `gcloud storage` で data-dev datalake を読むために、Cursor Secrets へ `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` を足す手順を runbook に書いた。あわせて `AGENTS.md` の Cursor 節から Environment setup を外し、エージェントが守る禁止事項だけ残した。

## Why
ADC（`GOOGLE_APPLICATION_CREDENTIALS`）だけでは `gcloud storage ls` が届かない。gcloud CLI は ADC を見ず、アカウント未選択で落ちる。値は `GOOGLE_APPLICATION_CREDENTIALS` と同じ `/home/ubuntu/.config/gcloud/cursor-wif.json` で、type は `Environment Variable`。

Cursor Environment の Secret 配線はすでに入っている。エージェント向けガイドに Dashboard の type や `start` スクリプトを書く必要はない。

## 関連 Issue
なし

## 変更内容
- `docs/runbooks/cursor-cloud-oidc-wif.md` の Secrets 表に `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` を追加
- 動作確認に `gcloud storage ls` を追加
- トラブルシュートに `You do not currently have an active account selected` を追加
- `AGENTS.md` の Cursor 節を、鍵を置かない / impersonation しない / token 交換を手で繰り返さない / バケット名は `DATA_LAKE_BUCKET_NAME` / 手順の正本は runbook、に絞った

## 影響範囲
ドキュメントのみ。既存の ADC / crawler 経路は変えない。Dashboard の Secrets に 1 件足す運用変更がある。

## 確認方法
- runbook の Secrets 表・動作確認・トラブルシュートが同じパスを指すことを diff で確認した
- この Cloud Agent で `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=/home/ubuntu/.config/gcloud/cursor-wif.json` を付けて `gcloud storage ls gs://haru256-devgist-data-dev-datalake` を実行し、`cursor-cloud-wif-probe/` と `papers/` が見えた
- `gcloud auth application-default print-access-token` も成功した
- `AGENTS.md` に Secret type、`start` スクリプト、`aud`、`cursor_oidc_subjects` が残っていないことを grep で確認した

## レビュー観点
- 値を `GOOGLE_APPLICATION_CREDENTIALS` と揃えているか
- 鍵や JSON 本体を Secret に置いていないか
- `AGENTS.md` に Environment setup が残っていないか

## 補足
なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de65ee87-48e5-4391-8c18-d011cf91e9e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de65ee87-48e5-4391-8c18-d011cf91e9e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

