### PR TITLE
fix(cursor-cloud): Cloud Agent の start を CodeRabbit auth 失敗に強くする

### DIFF
--- a/docs/runbooks/cursor-cloud-oidc-wif.md
+++ b/docs/runbooks/cursor-cloud-oidc-wif.md
@@ -90,8 +90,10 @@ type を `Runtime Secret` にすると、agent は値を `[REDACTED]` としか�
 
 | 項目 | 値 |
 |---|---|
-| `start` | `scripts/cursor-cloud/setup-adc.sh` |
+| `start` | `scripts/cursor-cloud/start.sh` |
 | Network（egress を制限しているときだけ） | Environment の network access に `sts.googleapis.com`、`iam.googleapis.com`、`storage.googleapis.com`、`www.googleapis.com`、`oauth2.googleapis.com` を足す |
+
+`start.sh` は [`scripts/cursor-cloud/setup-adc.sh`](../../scripts/cursor-cloud/setup-adc.sh) を必須で呼ぶ。ADC の配線に失敗したら boot も失敗させる。続けて CodeRabbit CLI の `coderabbit auth login` を best-effort で試す。失敗しても boot は落とさない。`coderabbit` CLI は agentic API key を要求するので、`CODERABBIT_API_KEY` が user API key だと `auth login` は失敗するが、それは非致命として警告だけ出す。`CODERABBIT_API_KEY` を使うなら type は `Environment Variable`。
 
 既存の `install` / snapshot は残す。リポジトリに `.cursor/environment.json` は置かない。`install` で export した変数は Build 後に残らない。mint 自体は VM 内の Unix socket で、allowlist は不要である。ネットワークの階層は [Secrets & Network](https://cursor.com/docs/cloud-agent/security-network#network-access) を見る。
 

--- a/scripts/cursor-cloud/start.sh
+++ b/scripts/cursor-cloud/start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cursor Cloud Agent `start` entrypoint.
+#
+# 1. ADC / WIF wiring is mandatory: if it fails the boot must fail, because
+#    everything downstream (GCS, crawler) depends on it.
+# 2. CodeRabbit CLI auth is best-effort: it must never break the boot. The
+#    CLI needs an *agentic* API key; a user API key returns a non-zero exit,
+#    which previously made `start` fail even though ADC was fine.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/setup-adc.sh"
+
+if [[ -n "${CODERABBIT_API_KEY:-}" ]]; then
+  if coderabbit auth login --api-key "${CODERABBIT_API_KEY}"; then
+    printf 'coderabbit auth login: ok\n'
+  else
+    printf 'coderabbit auth login failed (non-fatal); CODERABBIT_API_KEY must be an agentic API key\n' >&2
+  fi
+else
+  printf 'CODERABBIT_API_KEY not set; skipping coderabbit auth login\n'
+fi

--- a/scripts/cursor-cloud/tests/test_scripts.py
+++ b/scripts/cursor-cloud/tests/test_scripts.py
@@ -15,6 +15,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MINT = ROOT / "cursor-gcp-oidc"
 SETUP = ROOT / "setup-adc.sh"
+START = ROOT / "start.sh"
 AUDIENCE = (
     "//iam.googleapis.com/projects/123456789012/locations/global/"
     "workloadIdentityPools/cursor/providers/oidc"
@@ -92,6 +93,64 @@ cat {fixture.as_posix()!r}
             body = json.loads(result.stdout)
             self.assertEqual(body["id_token"], "header.payload.sig")
             self.assertEqual(json.loads(request_log.read_text())["aud"], AUDIENCE)
+
+
+class StartTest(unittest.TestCase):
+    def _stub_coderabbit(self, stub_dir: Path, exit_code: int) -> None:
+        stub_dir.mkdir(parents=True, exist_ok=True)
+        stub = stub_dir / "coderabbit"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            'printf \'stub coderabbit called: %s\\n\' "$*"\n'
+            f"exit {exit_code}\n"
+        )
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+    def _run_start(self, home: Path, stub_dir: Path, env: dict[str, str]):
+        base = {
+            "HOME": str(home),
+            "CURSOR_WIF_PROJECT_NUMBER": "123456789012",
+            "PATH": f"{stub_dir}:{os.environ['PATH']}",
+        }
+        base.update(env)
+        return run([str(START)], base)
+
+    def test_start_writes_adc_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            stub_dir = Path(tmp) / "bin"
+            self._stub_coderabbit(stub_dir, exit_code=0)
+            result = self._run_start(home, stub_dir, {"CODERABBIT_API_KEY": "x"})
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue((home / ".config/gcloud/cursor-wif.json").exists())
+
+    def test_start_tolerates_coderabbit_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            stub_dir = Path(tmp) / "bin"
+            self._stub_coderabbit(stub_dir, exit_code=1)
+            result = self._run_start(home, stub_dir, {"CODERABBIT_API_KEY": "x"})
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("non-fatal", result.stderr)
+
+    def test_start_skips_coderabbit_when_key_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            stub_dir = Path(tmp) / "bin"
+            self._stub_coderabbit(stub_dir, exit_code=1)
+            result = self._run_start(home, stub_dir, {"CODERABBIT_API_KEY": ""})
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("skipping coderabbit", result.stdout)
+
+    def test_start_fails_when_adc_setup_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            stub_dir = Path(tmp) / "bin"
+            self._stub_coderabbit(stub_dir, exit_code=0)
+            result = self._run_start(
+                home, stub_dir, {"CURSOR_WIF_PROJECT_NUMBER": "not-a-number"}
+            )
+            self.assertNotEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Cloud Agent（dashboard-managed 環境）の `start` フェーズが `coderabbit auth login` の失敗で毎回 exit 1 になっていた問題を修正する。ADC/WIF の配線を必須、CodeRabbit CLI 認証を best-effort に分離する `scripts/cursor-cloud/start.sh` を追加し、Environment の `start` をこのラッパーに切り替える前提でドキュメントを更新する。

## Why
現行 VM の `start`（保存済み DB 環境）は次の 2 行だった。

```
scripts/cursor-cloud/setup-adc.sh
coderabbit auth login --api-key $CODERABBIT_API_KEY
```

`setup-adc.sh` は成功するが、`CODERABBIT_API_KEY` が user API key のため `coderabbit auth login` が「User API keys are not supported for the CLI. Please generate an agentic API key」で exit 1 になり、`start` フェーズ全体が失敗扱い（`start-user.status = 1`）になっていた。ADC は正常なのに boot が失敗と記録される状態を解消する。

## 関連 Issue
なし

## 変更内容
- `scripts/cursor-cloud/start.sh` を追加。`setup-adc.sh` を必須で実行（失敗時は boot も失敗）し、`CODERABBIT_API_KEY` があるときだけ `coderabbit auth login` を best-effort で試す（失敗しても非致命の警告のみ、boot は継続）。
- `docs/runbooks/cursor-cloud-oidc-wif.md` の Environment `start` 値を `scripts/cursor-cloud/start.sh` に更新し、CodeRabbit を best-effort とする挙動を明記。
- `scripts/cursor-cloud/tests/test_scripts.py` に `start.sh` の unit test を追加（ADC config 書き込み / CodeRabbit 失敗の許容 / key 未設定時のスキップ / ADC 失敗は致命）。

## 影響範囲
- Cloud Agent の起動挙動のみ。ADC/WIF による GCP direct resource access の設計は不変（[INFRA-ADR-014](../adr/infra/014-cursor-oidc-wif-direct-resource-access.md) / [INFRA-ADR-015](../adr/infra/015-guest-iam-downstream.md)）。
- Secret・egress・IAM・snapshot の変更なし。`.cursor/environment.json` は追加しない。
- dashboard-managed 環境の `start` を本 PR のラッパーに向ける必要がある（Environment 設定の Save が別途必要）。

## 確認方法
- `python3 scripts/cursor-cloud/tests/test_scripts.py -v` → 6 tests OK。
- 実 VM で `scripts/cursor-cloud/start.sh` を実行 → `start.sh exit=0`、ADC config 書き込み、CodeRabbit は非致命警告。
- `gcloud auth application-default print-access-token` で OIDC/WIF トークン mint 成功、mint helper `--success == true`。
- `make -C workflows/crawler install` / `make lint` / `make test`（82 passed）idempotent 確認。

## レビュー観点
- `start.sh` の責務分離（ADC 必須 / CodeRabbit best-effort）が意図どおりか。
- runbook の `start` 記述更新が実運用と整合しているか。

## 補足
`CODERABBIT_API_KEY` は現状 user API key のため `coderabbit auth login` は失敗するが非致命。CodeRabbit CLI を実際に認証したい場合は、Secret（type `Environment Variable`）を agentic API key に差し替える必要がある。これは本 PR の環境検証をブロックしない。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be1ebba0-5ffc-4080-a82f-58175e8d6524?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be1ebba0-5ffc-4080-a82f-58175e8d6524&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

