### PR TITLE
Crawler Deploy 改名と GitHub Actions の最新 major 更新

### DIFF
--- a/.github/actions/find_target_projects/action.yaml
+++ b/.github/actions/find_target_projects/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Get changed directories
       id: changed-files
-      uses: tj-actions/changed-files@6cb76d07bee4c9772c6882c06c37837bf82a04d3 # v46
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
       with:
         matrix: true # 後続のjobでmatrixで使うために、ファイルをjson形式で出力させる
         dir_names: true # uniqueディレクトリ名を取得
@@ -32,7 +32,7 @@ runs:
         echo "::debug::Changed files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
       shell: bash
     - name: Find Target Projects
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       id: find-target-projects
       env:
         TARGET_PROJECTS: ${{ inputs.target_projects }}

--- a/.github/workflows/crawler-deploy.yaml
+++ b/.github/workflows/crawler-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
       IMAGE_TAG: ${{ github.sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -45,7 +45,7 @@ jobs:
         run: gcloud auth configure-docker "${REPO_URL%%/*}" --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         run: |

--- a/.github/workflows/crawler-deploy.yaml
+++ b/.github/workflows/crawler-deploy.yaml
@@ -1,4 +1,4 @@
-name: Crawler image
+name: Crawler Deploy
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - "workflows/crawler/**"
       - "!workflows/crawler/**/*.md"
       - "!workflows/crawler/docs/**"
-      - ".github/workflows/crawler-image.yml"
+      - ".github/workflows/crawler-deploy.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,7 +29,7 @@ jobs:
       projects: ${{ steps.find-target-projects.outputs.projects }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/find_target_projects/
@@ -58,9 +58,9 @@ jobs:
         working-directory: ${{ matrix.project }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "${{ matrix.project }}/pyproject.toml"

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -72,10 +72,10 @@ jobs:
       module_roots_count: ${{ steps.find-roots.outputs.module_roots_count }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -94,7 +94,7 @@ jobs:
         root: ${{ fromJson(needs.find_terraform_roots.outputs.environment_roots) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Terraform check
         uses: ./.github/actions/terraform-check
@@ -112,7 +112,7 @@ jobs:
         root: ${{ fromJson(needs.find_terraform_roots.outputs.module_roots) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Terraform check
         uses: ./.github/actions/terraform-check
@@ -125,10 +125,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Scan Terraform with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: infra/terraform

--- a/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
+++ b/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
@@ -279,7 +279,7 @@ GitHub の repository variable は ops Terraform が書く（[INFRA-ADR-017](./0
 - [[INFRA-ADR-014] Cursor Cloud の GCP 権限は WIF federated principal への direct resource access とする](./014-cursor-oidc-wif-direct-resource-access.md)（superseded。認証モデルは 015 が維持する）
 - [[INFRA-ADR-015] data は箱とし、guest IAM は依存の下流が書く](./015-guest-iam-downstream.md)
 - [[INFRA-ADR-017] GitHub Actions の Terraform 由来設定は ops が repository variable として書く](./017-github-actions-terraform-managed-variables.md)
-- [crawler image workflow](../../../.github/workflows/crawler-image.yml)
+- [Crawler Deploy workflow](../../../.github/workflows/crawler-deploy.yaml)
 - [crawler README](../../../workflows/crawler/README.md)
 - [Infrastructure README](../../../infra/README.md)
 - [issue #60](https://github.com/haru-256/devgist/issues/60)

--- a/docs/adr/infra/017-github-actions-terraform-managed-variables.md
+++ b/docs/adr/infra/017-github-actions-terraform-managed-variables.md
@@ -121,7 +121,7 @@ devgist-ops Terraform
     ├── CRAWLER_REPO_URL
     └── CRAWLER_IMAGE_NAME
 
-GitHub Actions crawler-image.yml
+GitHub Actions crawler-deploy.yaml
 ├── environment: dev
 ├── vars.CRAWLER_REPO_URL → REPO_URL
 ├── vars.CRAWLER_IMAGE_NAME → IMAGE_NAME
@@ -161,14 +161,14 @@ GitHub Actions crawler-image.yml
 1. `devgist-ops` に GitHub provider、Environment `dev`、repository variable を定義する
 2. 手元 apply の前に、既存の Environment `dev` を `terraform import github_repository_environment.dev devgist:dev` する
 3. `GITHUB_TOKEN` を入れて ops を apply する
-4. crawler image workflow が `vars.CRAWLER_REPO_URL` / `vars.CRAWLER_IMAGE_NAME` / `vars.GCP_GITHUB_WIF_PROVIDER` を読むことを確認する
+4. Crawler Deploy workflow が `vars.CRAWLER_REPO_URL` / `vars.CRAWLER_IMAGE_NAME` / `vars.GCP_GITHUB_WIF_PROVIDER` を読むことを確認する
 
 ## Related Documents
 
 - [[INFRA-ADR-004] Terraform State Project と Ops Project を分離する](./004-separate-tf-and-ops-projects.md)
 - [[INFRA-ADR-007] Artifact Registry リポジトリ戦略とワークロード用 Service Account 設計](./007-artifact-registry-and-sa-strategy.md)
 - [[INFRA-ADR-016] GitHub Actions から crawler image を Artifact Registry へ push する](./016-github-actions-wif-and-crawler-image-push.md)
-- [crawler image workflow](../../../.github/workflows/crawler-image.yml)
+- [Crawler Deploy workflow](../../../.github/workflows/crawler-deploy.yaml)
 - [crawler README](../../../workflows/crawler/README.md)
 - [Infrastructure README](../../../infra/README.md)
 - [issue #60](https://github.com/haru-256/devgist/issues/60)

--- a/workflows/crawler/README.md
+++ b/workflows/crawler/README.md
@@ -94,7 +94,7 @@ graph LR
 
 - `Cloud Run Job` は Terraform で管理する（[INFRA-ADR-010](../../docs/adr/infra/010-cloud-run-job-management.md)）
 - カンファレンス論文クロールは **単一の汎用 Cloud Run Job** で運用し、実行時に `CONFERENCE_NAMES` と `YEARS` を上書きする（[INFRA-ADR-012](../../docs/adr/infra/012-crawler-execution-parameters.md)）
-- コンテナイメージは `Artifact Registry` に保存する。`workflows/crawler` の image に効く変更、または crawler image workflow 自身が push されると GitHub Actions が build / push する。README だけでは走らない。ops を apply する前は repository variable が空なので job は skip する
+- コンテナイメージは `Artifact Registry` に保存する。`workflows/crawler` の image に効く変更、または Crawler Deploy workflow 自身が push されると GitHub Actions が build / push する。README だけでは走らない。ops を apply する前は repository variable が空なので job は skip する
 - GitHub Actions の image tag は `GITHUB_SHA`。同じ tag があっても build し直す
 - 手元の `make build-push-image` の tag は現在の HEAD の短縮 SHA（`IMAGE_TAG` で上書きできる）。CI の tag とは一致しないことがある
 - GitHub Actions からの image push の認証と IAM は [INFRA-ADR-016](../../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md) に従う。`REPO_URL` / `IMAGE_NAME` / WIF provider は ops Terraform が GitHub の repository variable に書く（[INFRA-ADR-017](../../docs/adr/infra/017-github-actions-terraform-managed-variables.md)）
@@ -106,7 +106,7 @@ graph LR
 ### 実行例
 
 ```bash
-# 1. GitHub Actions の Crawler image workflow が image_ref を出す
+# 1. GitHub Actions の Crawler Deploy workflow が image_ref を出す
 #    workflow_dispatch でも同じ。ログと job summary を見る
 # image_ref: us-central1-docker.pkg.dev/haru256-devgist-ops/crawler/crawler@sha256:...
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR
crawler の workflow を `Crawler Deploy` / `crawler-deploy.yaml` に改名し、リポジトリ内の GitHub Actions を最新 major に揃えた。ロジック変更はなく、YAML の `name` / `uses` とドキュメント参照の更新のみ（+24 / -24）。

## Why
1. **運用名の統一**: Actions タブの表示名とファイル名を `Crawler Deploy` に揃える。
2. **依存の更新**: 利用中 action の古い major（checkout v6、setup-buildx v3 など）を最新に上げる。

## 関連 Issue
なし

## レビューの入口
| 優先 | ファイル | 見ること |
| --- | --- | --- |
| 1 | `.github/workflows/crawler-deploy.yaml` | 改名・path filter・checkout v7 / buildx v4 |
| 2 | `.github/workflows/terraform-ci.yml` | checkout v7、setup-python v7、trivy v0.36.0 |
| 3 | `.github/workflows/python-ci.yml` | checkout v7、setup-uv v10.0.1 |
| 4 | `.github/actions/find_target_projects/action.yaml` | changed-files v47.0.6 SHA、github-script v9 |
| 5 | `workflows/crawler/README.md`、INFRA-ADR-016 / 017 | リンク・表記の追従のみ |

**触っていないもの**: `terraform-check`（`setup-terraform@v4`、`setup-tflint@v6` は既に最新）、crawler の GCP auth（`google-github-actions/auth@v3`、`setup-gcloud@v3`）、Terraform 変数、ADR 本文の方針。

## 変更内容

### Crawler Deploy 改名
- `.github/workflows/crawler-image.yml` → `.github/workflows/crawler-deploy.yaml`（`git mv`）
- workflow `name`: `Crawler Deploy`
- path filter を新ファイルパスに更新
- README / ADR の workflow 参照を追従

### Action version bumps

| Action | 変更前 | 変更後 | 主な利用箇所 |
| --- | --- | --- | --- |
| `actions/checkout` | v6 | v7 | terraform-ci、python-ci、crawler-deploy |
| `actions/setup-python` | v6 | v7 | terraform-ci |
| `docker/setup-buildx-action` | v3 | v4 | crawler-deploy |
| `aquasecurity/trivy-action` | 0.35.0 | v0.36.0 | terraform-ci |
| `astral-sh/setup-uv` | v7 | v10.0.1 | python-ci |
| `actions/github-script` | v7 | v9 | find_target_projects |
| `tj-actions/changed-files` | v46 SHA | v47.0.6 SHA | find_target_projects |

`setup-uv` は v8 以降 major タグ（`@v10`）を出していないため、immutable な `v10.0.1` を直接参照している。

## 影響範囲
- **Crawler Deploy**: Actions 表示名と concurrency group（`${{ github.workflow }}`）が変わる。WIF は repository / owner id 条件なので改名では壊れない。
- **checkout v7**: `pull_request_target` / `workflow_run` での fork PR checkout 拒否が入るが、本 PR の workflow は `pull_request` / `push` / `workflow_dispatch` だけなので影響なし。
- **setup-uv v10**: `enable-cache: true` を明示しているため、python-ci のキャッシュは維持される。
- **github-script v9**: `find_target_project.js` は `require('@actions/github')` を使っていないので互換性問題なし。

## 確認方法
- [x] `PYTHONPATH=.github/scripts python3 -m pytest .github/scripts/tests -v`（5 passed）
- [x] `.github` 配下に旧 pin（checkout@v6、setup-python@v6、setup-uv@v7、trivy-action@0.35.0、github-script@v7、changed-files v46）が残っていないこと
- [x] 旧ファイル `.github/workflows/crawler-image.yml` が無いこと
- [ ] merge 後: Terraform CI / Python CI / Crawler Deploy が Actions 上で緑になること（major 上げの実走確認）

## レビュー観点
- crawler 改名と action bump が意図どおり分かれているか
- ADR はリンク修正のみで方針本文を変えていないか
- major 上げで `with:` 入力の削除・必須化が起きていないか

## Commits（3）
1. `rename crawler image GHA to Crawler Deploy` — 改名とドキュメント追従
2. `chore(gha): bump Crawler Deploy actions to latest majors` — crawler-deploy の checkout / buildx
3. `chore(gha): align remaining Actions with latest majors` — 他 workflow / composite action

## 補足
なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87e820bc-9c50-461e-ac12-6a9d9f70361d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e820bc-9c50-461e-ac12-6a9d9f70361d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

