### PR TITLE
Artifact Registry の scanning OFF と image cleanup

### DIFF
--- a/.github/actions/terraform-check/action.yml
+++ b/.github/actions/terraform-check/action.yml
@@ -41,7 +41,23 @@ runs:
     - name: Terraform init
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: terraform init -backend=false -input=false
+      run: |
+        set -euo pipefail
+        # Provider downloads from releases.hashicorp.com can fail transiently
+        # (connection reset). Retry a few times before failing the job.
+        attempts=3
+        for attempt in $(seq 1 "${attempts}"); do
+          if terraform init -backend=false -input=false; then
+            exit 0
+          fi
+          if [ "${attempt}" -eq "${attempts}" ]; then
+            echo "terraform init failed after ${attempts} attempts" >&2
+            exit 1
+          fi
+          sleep_seconds=$((attempt * 5))
+          echo "terraform init failed (attempt ${attempt}/${attempts}); retrying in ${sleep_seconds}s..." >&2
+          sleep "${sleep_seconds}"
+        done
 
     - name: Terraform validate
       if: ${{ inputs.skip-validate != 'true' }}

--- a/.github/actions/terraform-check/action.yml
+++ b/.github/actions/terraform-check/action.yml
@@ -41,23 +41,7 @@ runs:
     - name: Terraform init
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
-        set -euo pipefail
-        # Provider downloads from releases.hashicorp.com can fail transiently
-        # (connection reset). Retry a few times before failing the job.
-        attempts=3
-        for attempt in $(seq 1 "${attempts}"); do
-          if terraform init -backend=false -input=false; then
-            exit 0
-          fi
-          if [ "${attempt}" -eq "${attempts}" ]; then
-            echo "terraform init failed after ${attempts} attempts" >&2
-            exit 1
-          fi
-          sleep_seconds=$((attempt * 5))
-          echo "terraform init failed (attempt ${attempt}/${attempts}); retrying in ${sleep_seconds}s..." >&2
-          sleep "${sleep_seconds}"
-        done
+      run: terraform init -backend=false -input=false
 
     - name: Terraform validate
       if: ${{ inputs.skip-validate != 'true' }}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@
 | `INFRA-ADR-015` | `infra` | data は箱とし、guest IAM は依存の下流が書く | Accepted | [docs/adr/infra/015-guest-iam-downstream.md](infra/015-guest-iam-downstream.md) |
 | `INFRA-ADR-016` | `infra` | GitHub Actions から crawler image を Artifact Registry へ push する | Accepted | [docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md](infra/016-github-actions-wif-and-crawler-image-push.md) |
 | `INFRA-ADR-017` | `infra` | GitHub Actions の Terraform 由来設定は ops が repository variable として書く | Accepted | [docs/adr/infra/017-github-actions-terraform-managed-variables.md](infra/017-github-actions-terraform-managed-variables.md) |
+| `INFRA-ADR-018` | `infra` | Artifact Registry の vulnerability scanning と image retention | Accepted | [docs/adr/infra/018-artifact-registry-cost-controls.md](infra/018-artifact-registry-cost-controls.md) |
 | `CRAWLER-ADR-001` | `crawler` | 論文収集クローラーの実装言語としてPythonを採用 | Accepted | [docs/adr/crawler/001-language-selection.md](crawler/001-language-selection.md) |
 | `CRAWLER-ADR-002` | `crawler` | XMLパースにdefusedxmlを採用 | Accepted | [docs/adr/crawler/002-xml-parsing-security.md](crawler/002-xml-parsing-security.md) |
 

--- a/docs/adr/infra/010-cloud-run-job-management.md
+++ b/docs/adr/infra/010-cloud-run-job-management.md
@@ -269,7 +269,7 @@ Terraform は以下を担当する。
 ### Risks / Future Review (将来の課題)
 
 - Terraform apply の失敗時に、Artifact Registry に未使用 image が残る可能性がある
-- 古い image の retention policy を検討する必要がある
+- 古い image の retention policy は [INFRA-ADR-018](./018-artifact-registry-cost-controls.md) で決めた
 - CI/CD 用 Service Account の権限が広くなりすぎないようにする必要がある
 - Terraform state bucket の IAM を適切に分離する必要がある
 - 複数 job / 複数 environment に増えたとき、Terraform module の抽象化粒度を見直す必要がある
@@ -295,4 +295,5 @@ Terraform は以下を担当する。
 
 - [Design Doc: DevGist](../../../docs/design_doc.md)
 - [INFRA-ADR-003 Crawler実行基盤として Cloud Run Jobs を採用する](./003-crawler-execution-platform.md)
+- [[INFRA-ADR-018] Artifact Registry の vulnerability scanning と image retention](./018-artifact-registry-cost-controls.md)
 - [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
+++ b/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
@@ -260,7 +260,7 @@ GitHub の repository variable は ops Terraform が書く（[INFRA-ADR-017](./0
 
 - public repo なので、この provider を呼ぶ workflow は default branch に入ったものが federate できる。`environment: dev` を付けた job は crawler AR writer を共有する。権限を分けたいときは GitHub Environment 名を分ける
 - GitHub Environment `dev` は OIDC claim と IAM の `attribute.environment` の契約であり、image の行き先ではない。protection rule は付けない。prod 用 Environment はまだ作らない。本体は ops Terraform が書く（[INFRA-ADR-017](./017-github-actions-terraform-managed-variables.md)）
-- Artifact Registry の retention は 010 のまま未決である
+- Artifact Registry の retention は [INFRA-ADR-018](./018-artifact-registry-cost-controls.md) で決めた（直近 5 世代 KEEP / 30 日超 DELETE。scanning は `DISABLED`）
 - apply の CI を足すときは、tfstate と Cloud Run の IAM がこの principalSet に乗る。そのときの blast radius を別 ADR で書く
 
 ## Next Steps
@@ -279,6 +279,7 @@ GitHub の repository variable は ops Terraform が書く（[INFRA-ADR-017](./0
 - [[INFRA-ADR-014] Cursor Cloud の GCP 権限は WIF federated principal への direct resource access とする](./014-cursor-oidc-wif-direct-resource-access.md)（superseded。認証モデルは 015 が維持する）
 - [[INFRA-ADR-015] data は箱とし、guest IAM は依存の下流が書く](./015-guest-iam-downstream.md)
 - [[INFRA-ADR-017] GitHub Actions の Terraform 由来設定は ops が repository variable として書く](./017-github-actions-terraform-managed-variables.md)
+- [[INFRA-ADR-018] Artifact Registry の vulnerability scanning と image retention](./018-artifact-registry-cost-controls.md)
 - [Crawler Deploy workflow](../../../.github/workflows/crawler-deploy.yaml)
 - [crawler README](../../../workflows/crawler/README.md)
 - [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/018-artifact-registry-cost-controls.md
+++ b/docs/adr/infra/018-artifact-registry-cost-controls.md
@@ -1,0 +1,133 @@
+# INFRA-ADR-018 Artifact Registry の vulnerability scanning と image retention
+
+## Conclusion (結論)
+
+- Artifact Registry repository は vulnerability scanning を **明示的に `DISABLED`** にする。`INHERITED` にしない。
+- 古い image は cleanup policy で消す。パッケージごとに **直近 5 世代を KEEP** し、**30 日より古い version を DELETE** する（KEEP が勝つ）。
+- 実装は `infra/terraform/modules/artifact_registry` に置く。ops の crawler リポジトリを含む、このモジュール経由の全 Docker repository に適用する。
+
+## Status (ステータス)
+
+Accepted (2026-08-29)
+
+## Context (背景・課題)
+
+### 背景
+
+crawler image は Artifact Registry（`devgist-ops`）に置き、Cloud Run Job は digest で参照する（[INFRA-ADR-007](./007-artifact-registry-and-sa-strategy.md)、[INFRA-ADR-010](./010-cloud-run-job-management.md)、[INFRA-ADR-016](./016-github-actions-wif-and-crawler-image-push.md)）。
+
+[INFRA-ADR-010](./010-cloud-run-job-management.md) と [INFRA-ADR-016](./016-github-actions-wif-and-crawler-image-push.md) は retention を未決のまま残していた。Crawler Deploy は `GITHUB_SHA` で毎回 push するため、cleanup が無いと storage 課金が増え続ける。
+
+Terraform の `google_artifact_registry_repository` で `vulnerability_scanning_config` を省略すると `INHERITED` 相当になる。プロジェクトで Container Scanning API を有効にすると、リポジトリ単位で拒否していない限りスキャン課金が発生し得る。
+
+### 要件と制約
+
+1. **課金抑制**
+   - vulnerability scanning 課金を避ける
+   - 使わない古い image の storage を抑える
+2. **rollback 余地**
+   - Cloud Run は digest pin なので、直近数世代は残す
+3. **明示性**
+   - 「API が無いから実質 off」ではなく、リポジトリ設定で OFF を宣言する
+4. **運用シンプルさ**
+   - 初期フェーズでは複雑なタグ規則や環境別 retention は避ける
+
+### 比較した選択肢
+
+#### Vulnerability scanning
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: 省略（INHERITED） | プロジェクト方針に追従したい場合 | 記述が短い | API 有効化で意図せずスキャンが走る | 非採用 |
+| Option B: `DISABLED` を明示 | スキャン課金をリポジトリ単位で止めたい場合 | 意図が Terraform に残る。API を後から有効にしても除外される | セキュリティスキャンは別経路が必要 | 採用 |
+
+#### Retention
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: 無制限保持 | 監査で全履歴が要る場合 | 失うものがない | storage が単調増加 | 非採用 |
+| Option B: KEEP 直近 N のみ（DELETE 無し） | 試験中 | 設定が単純 | DELETE が無いと何も消えない | 非採用 |
+| Option C: KEEP 直近 5 + DELETE 30 日超 | 個人開発で rollback と課金のバランスを取る場合 | 直近は残る。古いものは消える。KEEP が DELETE に勝つ | 30 日以内に 5 を超えると古い方は残る | 採用 |
+| Option D: KEEP 直近 5 + DELETE 即時（年齢ほぼ 0） | storage を最小にしたい場合 | 世代数が厳密に 5 付近になる | 誤削除リスクが高い | 非採用 |
+
+### 選定観点
+
+- 課金を抑える明示的な設定か
+- digest pin の rollback に足りる世代があるか
+- Terraform module 1 箇所で全 app repository に適用できるか
+
+## Considered Options
+
+### Option A: scanning を省略し、retention も後回し [却下]
+
+現状維持。ADR-010 / 016 の「未決」を残す。
+
+却下理由: push のたびに storage が増え、scanning も `INHERITED` のまま意図が曖昧。
+
+### Option B: scanning `DISABLED` + KEEP 5 / DELETE 30d [採用]
+
+module で両方を宣言する。
+
+採用理由:
+
+- Container Scanning API を後から有効にしても、この repository はスキャン対象外になる
+- KEEP が DELETE に勝つので、直近 5 世代は 30 日を超えても残る
+- 30 日以内に 5 を超えた分は、年齢条件に入るまで残る（過剰削除を避ける）
+
+## Decision (決定事項)
+
+Artifact Registry の Docker repository は vulnerability scanning を `DISABLED` にし、cleanup policy で直近 5 世代を KEEP・30 日より古い version を DELETE する。
+
+### 採用方針
+
+- `vulnerability_scanning_config.enablement_config = "DISABLED"`
+- cleanup policy:
+  - `keep-minimum-versions` (`KEEP`, `most_recent_versions.keep_count = 5`)
+  - `delete-older-than` (`DELETE`, `tag_state = ANY`, `older_than = 30d`)
+- `cleanup_policy_dry_run` の初期値は `false`（実際に削除する）
+- keep / older_than は module 変数で上書きできるが、デフォルトは上記
+
+### 初期構成
+
+- 適用対象: `artifact_registry` module で作る全 repository（現状 `crawler`）
+- Container Scanning API は ops の `required_services` に入れない（現状維持）
+- Cloud Run / GKE とのリージョン揃えは [INFRA-ADR-007](./007-artifact-registry-and-sa-strategy.md) と既存 `gcp_default_region` のまま
+
+### 再検討条件
+
+- コンプライアンスで脆弱性スキャン必須になった場合（別経路のスキャン含む）
+- rollback に 5 世代では足りない、または 30 日では storage が厚い場合
+- prod 専用 retention（より長く残す）が必要になった場合
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- scanning 課金をリポジトリ単位で明示的に止められる
+- 古い image の storage 増加を抑えられる
+- digest pin の直近 rollback 用に 5 世代残る
+
+### Negative (デメリット)
+
+- 30 日を超え、かつ直近 5 世代に入らない digest は消える。長い間 apply していない Cloud Run の旧 digest 参照は pull できなくなる
+- Artifact Registry の cleanup はバックグラウンドジョブなので、反映まで最大おおよそ 1 日かかることがある
+
+### Risks / Future Review (将来の課題)
+
+- apply 直後に dry-run へ一時切替して監査ログを見る運用が必要なら、`cleanup_policy_dry_run` を true にして再 apply する
+- untagged digest だけの掃除が必要なら、DELETE 条件を足す
+
+## Next Steps
+
+1. `artifact_registry` module に scanning `DISABLED` と cleanup policy を入れる
+2. `devgist-ops` を手元で `terraform plan` / `apply` する（Cloud Agent からは AR 権限が無い）
+3. apply 後、Console または権限のあるアカウントで scanning が Disabled・cleanup が有効であることを確認する
+
+## Related Documents
+
+- [[INFRA-ADR-007] Artifact Registry リポジトリ戦略とワークロード用 Service Account 設計](./007-artifact-registry-and-sa-strategy.md)
+- [[INFRA-ADR-010] Cloud Run Job の管理責務を Terraform に集約する](./010-cloud-run-job-management.md)
+- [[INFRA-ADR-016] GitHub Actions から crawler image を Artifact Registry へ push する](./016-github-actions-wif-and-crawler-image-push.md)
+- [artifact_registry module](../../../infra/terraform/modules/artifact_registry/README.md)
+- [Artifact Registry cleanup policies](https://docs.cloud.google.com/artifact-registry/docs/repositories/cleanup-policy)
+- [Control scanning settings for a repository](https://docs.cloud.google.com/artifact-analysis/docs/enable-automatic-scanning)

--- a/infra/README.md
+++ b/infra/README.md
@@ -24,6 +24,7 @@
 - `INFRA-ADR-015`: [docs/adr/infra/015-guest-iam-downstream.md](../docs/adr/infra/015-guest-iam-downstream.md)
 - `INFRA-ADR-016`: [docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md](../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md)
 - `INFRA-ADR-017`: [docs/adr/infra/017-github-actions-terraform-managed-variables.md](../docs/adr/infra/017-github-actions-terraform-managed-variables.md)
+- `INFRA-ADR-018`: [docs/adr/infra/018-artifact-registry-cost-controls.md](../docs/adr/infra/018-artifact-registry-cost-controls.md)
 
 このディレクトリ配下の `infra/docs/adr/` は互換性維持のための参照パスであり、正本は [docs/adr/](../docs/adr/) 側です。
 

--- a/infra/terraform/modules/artifact_registry/.terraform.lock.hcl
+++ b/infra/terraform/modules/artifact_registry/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:p1/8oF64IGjiI47qa4OlsagwgtqGZUT5UU0Vtjv9g9M=",
+    "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
+    "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
+    "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
+    "zh:60c96075fc082d9584b9cb8f48f0d23f90fd4344e6141a417580c6bad1b21957",
+    "zh:ad82cece07a0816153e3fc6cb6d7672c6c009742dc802ab434a83d0731d94ae7",
+    "zh:aebbf8a0bd3af0b6c705d5d85ec51891f533b83dcbae7249e64a252efc6fd862",
+    "zh:bfbb19a5b46950eaf0a83cea09a5992d1b0e96792130faeb6c733609dc2913df",
+    "zh:c196b4c82d0252fa751ee3cd84433bc483b7ce7d6fcab5db0413dbaa9f218650",
+    "zh:db1c83777bc6d7fc195be83712a9f503e9a5a1f7326fd6968d9812acc53f2056",
+    "zh:dcd58beeac9d1889e5532cfcd3bd8dec5568ab06b0a81427bc9b35931b6f0178",
+    "zh:eaeedc86c2d01630a3166ae98d5138e9bf9463b2a606d7f7df6d465d1501f28f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.18.0"
+  constraints = "~> 7.18.0"
+  hashes = [
+    "h1:qf+lQn4pQLcsIzX47cjYzTGA1X9TOaY+MQapdCX0OjQ=",
+    "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
+    "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
+    "zh:5064a8ffda6f8c6b5e72842623a6dc433fd8d8e4013f9266e2636e140a674f6a",
+    "zh:5f383784682442c67a145c4c9117864da735b149aa0e6feefb7f5c0eab738e63",
+    "zh:7fb9526dfeae6e9edd61badfd2c6c64e690e332330a88ccc8deb837d8d08cfc7",
+    "zh:84d707e934b4a2d5bf8ff6ef4758328c93ece119e5fcda09686f47db4fb68e84",
+    "zh:9aab258c4a614f2c05468893891ba6af517c448389ad080831f12f4d52048646",
+    "zh:9f8d8d7c11697b36c0f5d4e54882d7448923bb8d5083a1e50ed63043cb60dda6",
+    "zh:ad9a5a714e60f31f2576b246ac6852b3423ed62ee9537cbabf7fd147207f9e77",
+    "zh:c1098525b4a7fa8aa39cef056718c0f176842defb7dc284bc66148377d5d125d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9b705921562316bdf89e2fb310c036d3cc7bb3bf973fef318da0888deea82fa",
+  ]
+}

--- a/infra/terraform/modules/artifact_registry/README.md
+++ b/infra/terraform/modules/artifact_registry/README.md
@@ -2,7 +2,7 @@
 
 GCP の Docker 用 `Artifact Registry repository` を作成するモジュールです。
 
-このモジュールは単一の repository を作ることだけを責務に持ちます。DevGist では project は共有しつつ、application / service ごとに repository を分けて運用する前提で使います。
+このモジュールは単一の repository を作ることだけを責務に持ちます。DevGist では project は共有しつつ、application / service ごとに repository を分けて運用する前提で使います。課金抑制として vulnerability scanning を `DISABLED` にし、cleanup policy で古い version を消す（[INFRA-ADR-018](../../../../docs/adr/infra/018-artifact-registry-cost-controls.md)）。
 
 ## Resources
 
@@ -16,6 +16,9 @@ GCP の Docker 用 `Artifact Registry repository` を作成するモジュール
 | `location` | repository のリージョン | `string` | n/a | yes |
 | `repository_id` | repository ID | `string` | n/a | yes |
 | `description` | repository の説明 | `string` | `""` | no |
+| `cleanup_keep_count` | パッケージごとに残す直近 version 数 | `number` | `5` | no |
+| `cleanup_delete_older_than` | KEEP 対象外で削除する年齢（例: `30d`） | `string` | `"30d"` | no |
+| `cleanup_policy_dry_run` | true なら削除せず dry-run のみ | `bool` | `false` | no |
 
 ## Outputs
 
@@ -25,6 +28,13 @@ GCP の Docker 用 `Artifact Registry repository` を作成するモジュール
 | `name` | Artifact Registry repository resource name | `string` |
 | `location` | Artifact Registry repository location | `string` |
 | `repository_url` | Docker push 用 URL | `string` |
+
+## Cost controls
+
+- `vulnerability_scanning_config.enablement_config = DISABLED`（プロジェクトで Container Scanning API を有効にしても、この repository はスキャンしない）
+- cleanup:
+  - `keep-minimum-versions`: 直近 `cleanup_keep_count` 世代を KEEP
+  - `delete-older-than`: `cleanup_delete_older_than` より古い version を DELETE（KEEP が勝つ）
 
 ## Usage
 

--- a/infra/terraform/modules/artifact_registry/main.tf
+++ b/infra/terraform/modules/artifact_registry/main.tf
@@ -4,4 +4,31 @@ resource "google_artifact_registry_repository" "repository" {
   repository_id = var.repository_id
   description   = var.description
   format        = "DOCKER"
+
+  # INFRA-ADR-018: never inherit project-level Container Scanning.
+  vulnerability_scanning_config {
+    enablement_config = "DISABLED"
+  }
+
+  # INFRA-ADR-018: KEEP wins over DELETE for matching versions.
+  cleanup_policy_dry_run = var.cleanup_policy_dry_run
+
+  cleanup_policies {
+    id     = "keep-minimum-versions"
+    action = "KEEP"
+
+    most_recent_versions {
+      keep_count = var.cleanup_keep_count
+    }
+  }
+
+  cleanup_policies {
+    id     = "delete-older-than"
+    action = "DELETE"
+
+    condition {
+      tag_state  = "ANY"
+      older_than = var.cleanup_delete_older_than
+    }
+  }
 }

--- a/infra/terraform/modules/artifact_registry/tests/cost_controls.tftest.hcl
+++ b/infra/terraform/modules/artifact_registry/tests/cost_controls.tftest.hcl
@@ -1,0 +1,51 @@
+mock_provider "google" {}
+mock_provider "google-beta" {}
+
+variables {
+  project_id    = "ops"
+  location      = "us-central1"
+  repository_id = "crawler"
+  description   = "Docker images for the crawler job"
+}
+
+run "disables_vulnerability_scanning" {
+  command = plan
+
+  assert {
+    condition = (
+      google_artifact_registry_repository.repository.vulnerability_scanning_config[0].enablement_config
+      == "DISABLED"
+    )
+    error_message = "Expected Artifact Registry vulnerability scanning to be DISABLED"
+  }
+}
+
+run "keeps_recent_versions_and_deletes_old" {
+  command = plan
+
+  assert {
+    condition     = google_artifact_registry_repository.repository.cleanup_policy_dry_run == false
+    error_message = "Expected cleanup policies to run actively (dry_run=false)"
+  }
+
+  assert {
+    condition = anytrue([
+      for policy in google_artifact_registry_repository.repository.cleanup_policies :
+      policy.id == "keep-minimum-versions" &&
+      policy.action == "KEEP" &&
+      try(policy.most_recent_versions[0].keep_count, 0) == 5
+    ])
+    error_message = "Expected KEEP policy keep-minimum-versions with keep_count=5"
+  }
+
+  assert {
+    condition = anytrue([
+      for policy in google_artifact_registry_repository.repository.cleanup_policies :
+      policy.id == "delete-older-than" &&
+      policy.action == "DELETE" &&
+      try(policy.condition[0].older_than, "") == "30d" &&
+      try(policy.condition[0].tag_state, "") == "ANY"
+    ])
+    error_message = "Expected DELETE policy delete-older-than with older_than=30d and tag_state=ANY"
+  }
+}

--- a/infra/terraform/modules/artifact_registry/variables.tf
+++ b/infra/terraform/modules/artifact_registry/variables.tf
@@ -18,3 +18,31 @@ variable "description" {
   description = "The description for the Artifact Registry repository."
   default     = ""
 }
+
+variable "cleanup_keep_count" {
+  type        = number
+  description = "Minimum number of most recent package versions to keep per package (INFRA-ADR-018)."
+  default     = 5
+
+  validation {
+    condition     = var.cleanup_keep_count >= 1
+    error_message = "cleanup_keep_count must be at least 1."
+  }
+}
+
+variable "cleanup_delete_older_than" {
+  type        = string
+  description = "Delete versions older than this duration unless kept by keep-minimum-versions (e.g. \"30d\")."
+  default     = "30d"
+
+  validation {
+    condition     = can(regex("^[0-9]+[smhd]$", var.cleanup_delete_older_than))
+    error_message = "cleanup_delete_older_than must be a duration like \"30d\", \"48h\", \"60m\", or \"3600s\"."
+  }
+}
+
+variable "cleanup_policy_dry_run" {
+  type        = bool
+  description = "When true, cleanup policies log candidates without deleting (INFRA-ADR-018)."
+  default     = false
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Artifact Registry の vulnerability scanning を明示的に `DISABLED` にし、古い image を cleanup policy で削除する（INFRA-ADR-018）。

## Why
storage / scanning 課金を抑えるため。これまで scanning は未設定（INHERITED）、retention は ADR-010 / 016 で未決のままだった。

## 関連 Issue
なし

## 変更内容
- `artifact_registry` module:
  - `vulnerability_scanning_config.enablement_config = DISABLED`
  - KEEP 直近 5 世代 + DELETE 30 日超（`cleanup_policy_dry_run = false`）
  - `cleanup_keep_count` / `cleanup_delete_older_than` / `cleanup_policy_dry_run` を変数化（デフォルトは上記）
- module terraform test を追加
- INFRA-ADR-018 を追加し、010 / 016 の「retention 未決」を 018 へ誘導

## 影響範囲
- ops の crawler repository（この module 経由の全 Docker repo）に適用
- 30 日を超え、かつ直近 5 世代に入らない digest は削除される
- cleanup は GCP のバックグラウンドジョブのため、反映まで最大おおよそ 1 日かかることがある
- **この PR では `terraform apply` していない**（手元 apply が必要）

## 確認方法
- [x] `terraform -chdir=infra/terraform/modules/artifact_registry test`（2 passed）
- [x] `terraform -chdir=infra/terraform/environments/devgist-ops test`（4 passed）
- [x] module / ops / data-dev `terraform validate`
- [ ] 手元で `devgist-ops` の `terraform plan` / `apply`（権限のあるアカウント）
- [ ] apply 後、Console で scanning Disabled と cleanup policy を確認

## レビュー観点
- KEEP 5 / DELETE 30d のバランスが運用に合うか
- `DISABLED` 明示で十分か（API 自体は引き続き ops `required_services` に入れない）
- apply 前に dry-run へ一時切替すべきか

## 補足
デフォルトの保持世代・削除年齢を変えたい場合は module 変数で上書きできる。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87e820bc-9c50-461e-ac12-6a9d9f70361d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e820bc-9c50-461e-ac12-6a9d9f70361d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

