### PR TITLE
feat: GitHub Actions から terraform plan / apply する（INFRA-ADR-019）

### DIFF
--- a/.github/actions/terraform-gcp-apply/action.yml
+++ b/.github/actions/terraform-gcp-apply/action.yml
@@ -1,0 +1,54 @@
+name: "Terraform GCP Apply"
+description: "Authenticate via GitHub WIF (direct access), init with the GCS backend, download the saved plan artifact, and apply it. Never runs a bare terraform apply (INFRA-ADR-019)."
+
+inputs:
+  working-directory:
+    description: "Terraform root directory"
+    required: true
+  terraform-version:
+    description: "Terraform version"
+    required: false
+    default: "1.14.8"
+  workload-identity-provider:
+    description: "WIF provider resource name (vars.GCP_GITHUB_WIF_PROVIDER)"
+    required: true
+  gcp-project-id:
+    description: "GCP project ID used as the quota project by the auth action"
+    required: false
+    default: "haru256-devgist-ops"
+  plan-artifact-name:
+    description: "Artifact name of the saved plan produced by terraform-gcp-plan"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v3
+      with:
+        project_id: ${{ inputs.gcp-project-id }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+        terraform_wrapper: false
+
+    - name: Terraform init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform init -backend-config=config.gcs.tfbackend -input=false
+
+    - name: Download plan artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.plan-artifact-name }}
+        path: ${{ inputs.working-directory }}
+
+    # saved plan を apply するので variable の再入力は不要。
+    # state が plan 後に変わっていれば Terraform が stale plan として失敗させる
+    - name: Terraform apply
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform apply -input=false -no-color tfplan

--- a/.github/actions/terraform-gcp-plan/action.yml
+++ b/.github/actions/terraform-gcp-plan/action.yml
@@ -1,0 +1,95 @@
+name: "Terraform GCP Plan"
+description: "Authenticate via GitHub WIF (direct access), init with the GCS backend, and run terraform plan. Optionally save the plan and upload it as an artifact (INFRA-ADR-019)."
+
+inputs:
+  working-directory:
+    description: "Terraform root directory"
+    required: true
+  terraform-version:
+    description: "Terraform version"
+    required: false
+    default: "1.14.8"
+  workload-identity-provider:
+    description: "WIF provider resource name (vars.GCP_GITHUB_WIF_PROVIDER)"
+    required: true
+  gcp-project-id:
+    description: "GCP project ID used as the quota project by the auth action"
+    required: false
+    default: "haru256-devgist-ops"
+  save-plan:
+    description: "Save the plan to tfplan and upload it as an artifact"
+    required: false
+    default: "false"
+  plan-artifact-name:
+    description: "Artifact name for the saved plan (required when save-plan is true)"
+    required: false
+    default: ""
+
+outputs:
+  plan-exit-code:
+    description: "terraform plan -detailed-exitcode result (0: no changes, 2: changes)"
+    value: ${{ steps.plan.outputs.plan-exit-code }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v3
+      with:
+        project_id: ${{ inputs.gcp-project-id }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+        terraform_wrapper: false
+
+    - name: Terraform init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform init -backend-config=config.gcs.tfbackend -input=false
+
+    # read-only principal では GCS backend の lock file を書けないので -lock=false。
+    # apply は同じ run の後続 job が saved plan を使う（INFRA-ADR-019）
+    - name: Terraform plan
+      id: plan
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SAVE_PLAN: ${{ inputs.save-plan }}
+      run: |
+        set -o pipefail
+        out_flag=()
+        if [ "${SAVE_PLAN}" = "true" ]; then
+          out_flag=(-out=tfplan)
+        fi
+        terraform plan -no-color -input=false -lock=false -detailed-exitcode "${out_flag[@]}" 2>&1 | tee plan.txt
+        code="${PIPESTATUS[0]}"
+        echo "plan-exit-code=${code}" >> "${GITHUB_OUTPUT}"
+        if [ "${code}" -eq 1 ]; then
+          exit 1
+        fi
+
+    - name: Show saved plan in summary
+      if: ${{ inputs.save-plan == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        {
+          echo "### terraform plan — \`${{ inputs.working-directory }}\`"
+          echo "- commit: \`${GITHUB_SHA}\`"
+          echo '```terraform'
+          terraform show -no-color tfplan | head -c 900000
+          echo '```'
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+    # tfplan は planned values を含み得る sensitive artifact。retention は 1 日（INFRA-ADR-019）
+    - name: Upload plan artifact
+      if: ${{ inputs.save-plan == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.plan-artifact-name }}
+        path: ${{ inputs.working-directory }}/tfplan
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/scripts/find_terraform_roots.py
+++ b/.github/scripts/find_terraform_roots.py
@@ -13,6 +13,13 @@ It writes the following key/value pairs to ``$GITHUB_OUTPUT`` when running in
 GitHub Actions, and prints the same key/value pairs to stdout for local use:
 ``environment_roots``, ``environment_roots_count``, ``module_roots``, and
 ``module_roots_count``.
+
+When ``--deploy-exclude`` is given, environment roots whose path relative to
+``environments/`` matches one of the excludes (e.g. ``devgist-tf`` or
+``github``) are additionally published as ``deploy_roots`` /
+``deploy_roots_count``. Deploy roots are the subset of environment roots that
+CI is allowed to plan / apply (INFRA-ADR-019). Without excludes, deploy roots
+equal environment roots.
 """
 
 from __future__ import annotations
@@ -52,6 +59,24 @@ def find_module_roots(terraform_dir: Path) -> list[Path]:
     return sorted(roots)
 
 
+def filter_deploy_roots(
+    environment_roots: list[Path],
+    terraform_dir: Path,
+    excludes: list[str],
+) -> list[Path]:
+    """Return environment roots minus the given deploy excludes.
+
+    ``excludes`` are matched against the root path relative to
+    ``environments/`` (e.g. ``devgist-tf`` or ``devgist-app/dev``).
+    """
+    environments_dir = terraform_dir / "environments"
+    return [
+        root
+        for root in environment_roots
+        if root.relative_to(environments_dir).as_posix() not in excludes
+    ]
+
+
 def write_github_output(values: dict[str, str]) -> None:
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output is None:
@@ -72,6 +97,16 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="Path to the Terraform monorepo directory.",
     )
+    parser.add_argument(
+        "--deploy-exclude",
+        nargs="*",
+        default=[],
+        metavar="ROOT",
+        help=(
+            "Environment roots (relative to environments/, e.g. 'devgist-tf') "
+            "to exclude from deploy_roots."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -81,17 +116,21 @@ def main() -> None:
 
     environment_roots = find_environment_roots(terraform_dir)
     module_roots = find_module_roots(terraform_dir)
+    deploy_roots = filter_deploy_roots(environment_roots, terraform_dir, args.deploy_exclude)
 
     values = {
         "environment_roots": to_json(environment_roots),
         "environment_roots_count": str(len(environment_roots)),
         "module_roots": to_json(module_roots),
         "module_roots_count": str(len(module_roots)),
+        "deploy_roots": to_json(deploy_roots),
+        "deploy_roots_count": str(len(deploy_roots)),
     }
     write_github_output(values)
 
     print(f"Terraform environment roots: {values['environment_roots']}")
     print(f"Terraform module roots: {values['module_roots']}")
+    print(f"Terraform deploy roots: {values['deploy_roots']}")
 
     if not environment_roots and not module_roots:
         raise SystemExit("No Terraform environment or module roots found.")

--- a/.github/scripts/tests/test_find_terraform_roots.py
+++ b/.github/scripts/tests/test_find_terraform_roots.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from find_terraform_roots import find_environment_roots, find_module_roots
+from find_terraform_roots import (
+    filter_deploy_roots,
+    find_environment_roots,
+    find_module_roots,
+)
 
 
 def touch(path: Path) -> None:
@@ -69,3 +73,40 @@ class TestFindModuleRoots:
 
     def test_returns_empty_when_modules_missing(self, tmp_path: Path) -> None:
         assert find_module_roots(tmp_path) == []
+
+
+class TestFilterDeployRoots:
+    def test_excludes_roots_by_relative_path(self, tmp_path: Path) -> None:
+        # Arrange
+        touch(tmp_path / "environments" / "devgist-app" / "dev" / "providers.tf")
+        touch(tmp_path / "environments" / "devgist-data" / "dev" / "providers.tf")
+        touch(tmp_path / "environments" / "devgist-ops" / "providers.tf")
+        touch(tmp_path / "environments" / "devgist-tf" / "providers.tf")
+        touch(tmp_path / "environments" / "github" / "providers.tf")
+        roots = find_environment_roots(tmp_path)
+
+        # Act
+        deploy_roots = filter_deploy_roots(roots, tmp_path, ["devgist-tf", "github"])
+
+        # Assert
+        assert deploy_roots == [
+            tmp_path / "environments" / "devgist-app" / "dev",
+            tmp_path / "environments" / "devgist-data" / "dev",
+            tmp_path / "environments" / "devgist-ops",
+        ]
+
+    def test_no_excludes_returns_all_environment_roots(self, tmp_path: Path) -> None:
+        # Arrange
+        touch(tmp_path / "environments" / "devgist-ops" / "providers.tf")
+        roots = find_environment_roots(tmp_path)
+
+        # Act / Assert
+        assert filter_deploy_roots(roots, tmp_path, []) == roots
+
+    def test_unknown_exclude_is_ignored(self, tmp_path: Path) -> None:
+        # Arrange
+        touch(tmp_path / "environments" / "devgist-ops" / "providers.tf")
+        roots = find_environment_roots(tmp_path)
+
+        # Act / Assert
+        assert filter_deploy_roots(roots, tmp_path, ["no-such-root"]) == roots

--- a/.github/workflows/crawler-deploy.yaml
+++ b/.github/workflows/crawler-deploy.yaml
@@ -1,7 +1,11 @@
 name: Crawler Deploy
 
+# INFRA-ADR-019: write 系の ci_scope は protected main に閉じる。
+# feature branch の push では ci_scope=none で token 交換が失敗するため、trigger 自体を main に限定する
 on:
   push:
+    branches:
+      - "main"
     paths:
       - "workflows/crawler/**"
       - "!workflows/crawler/**/*.md"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,154 @@
+name: Terraform Apply
+
+# INFRA-ADR-019: protected main への push で dev を自動 apply する。
+# root ごとに plan job（environment 無し → terraform-plan-dev）と
+# apply job（environment: dev → terraform-apply-dev）を組みにし、
+# INFRA-ADR-015 の DAG に従い data-dev → ops → app-dev の直列で実行する。
+# apply は saved plan（tfplan artifact）に限り、bare terraform apply は使わない。
+# prod は環境作成時に terraform-apply-prod.yml として別 workflow で足す
+# （dispatch の input は JWT claim に載らず、同じファイルでは plan job の ci_scope を分けられないため）。
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "infra/terraform/**"
+      - ".github/workflows/terraform-apply.yml"
+      - ".github/actions/terraform-gcp-plan/**"
+      - ".github/actions/terraform-gcp-apply/**"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Apply target environment (prod は terraform-apply-prod.yml として別途追加する)"
+        required: true
+        type: choice
+        default: "dev"
+        options:
+          - "dev"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  plan_data_dev:
+    name: plan / devgist-data/dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform plan
+        uses: ./.github/actions/terraform-gcp-plan
+        with:
+          working-directory: infra/terraform/environments/devgist-data/dev
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          save-plan: "true"
+          plan-artifact-name: tfplan-devgist-data-dev
+
+  apply_data_dev:
+    name: apply / devgist-data/dev
+    needs: plan_data_dev
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform apply
+        uses: ./.github/actions/terraform-gcp-apply
+        with:
+          working-directory: infra/terraform/environments/devgist-data/dev
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          plan-artifact-name: tfplan-devgist-data-dev
+
+  plan_ops:
+    name: plan / devgist-ops
+    needs: apply_data_dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_VAR_cursor_oidc_subjects: ${{ secrets.CURSOR_OIDC_SUBJECTS }}
+      TF_VAR_service_account_user_emails: ${{ secrets.SERVICE_ACCOUNT_USER_EMAILS }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform plan
+        uses: ./.github/actions/terraform-gcp-plan
+        with:
+          working-directory: infra/terraform/environments/devgist-ops
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          save-plan: "true"
+          plan-artifact-name: tfplan-devgist-ops
+
+  apply_ops:
+    name: apply / devgist-ops
+    needs: plan_ops
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform apply
+        uses: ./.github/actions/terraform-gcp-apply
+        with:
+          working-directory: infra/terraform/environments/devgist-ops
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          plan-artifact-name: tfplan-devgist-ops
+
+  plan_app_dev:
+    name: plan / devgist-app/dev
+    needs: apply_ops
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_VAR_service_account_user_emails: ${{ secrets.SERVICE_ACCOUNT_USER_EMAILS }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform plan
+        uses: ./.github/actions/terraform-gcp-plan
+        with:
+          working-directory: infra/terraform/environments/devgist-app/dev
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          save-plan: "true"
+          plan-artifact-name: tfplan-devgist-app-dev
+
+  apply_app_dev:
+    name: apply / devgist-app/dev
+    needs: plan_app_dev
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform apply
+        uses: ./.github/actions/terraform-gcp-apply
+        with:
+          working-directory: infra/terraform/environments/devgist-app/dev
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+          plan-artifact-name: tfplan-devgist-app-dev

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,117 @@
+name: Terraform Plan
+
+# INFRA-ADR-019: same-repo PR で speculative plan を実行し、結果を PR コメントに出す。
+# read-only の terraform-plan-dev principal。fork PR は OIDC token を取得できないうえ、
+# head repo ガードで auth 自体をスキップする。ここで生成した plan は apply には使わない。
+
+on:
+  pull_request:
+    paths:
+      - "infra/terraform/**"
+      - ".github/workflows/terraform-plan.yml"
+      - ".github/actions/terraform-gcp-plan/**"
+      - ".github/scripts/find_terraform_roots.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  find_terraform_roots:
+    name: Find Terraform deploy roots
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_roots: ${{ steps.find-roots.outputs.deploy_roots }}
+      deploy_roots_count: ${{ steps.find-roots.outputs.deploy_roots_count }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      # devgist-tf（tfstate 基盤）と github（GitHub リソース）はローカル apply のため対象外（INFRA-ADR-019）
+      - name: Find Terraform roots
+        id: find-roots
+        run: python .github/scripts/find_terraform_roots.py --terraform-dir infra/terraform --deploy-exclude devgist-tf github
+
+  terraform_plan:
+    name: terraform plan / ${{ matrix.root }}
+    needs: find_terraform_roots
+    # same-repo PR のみ authenticated plan を許可する（fork PR には secrets も OIDC token も出ない）
+    if: ${{ needs.find_terraform_roots.outputs.deploy_roots_count != '0' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        root: ${{ fromJson(needs.find_terraform_roots.outputs.deploy_roots) }}
+    env:
+      # ops / app-dev root の必須変数（INFRA-ADR-019）。宣言していない root では warning のみ
+      TF_VAR_cursor_oidc_subjects: ${{ secrets.CURSOR_OIDC_SUBJECTS }}
+      TF_VAR_service_account_user_emails: ${{ secrets.SERVICE_ACCOUNT_USER_EMAILS }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Terraform plan
+        id: plan
+        uses: ./.github/actions/terraform-gcp-plan
+        with:
+          working-directory: ${{ matrix.root }}
+          workload-identity-provider: ${{ vars.GCP_GITHUB_WIF_PROVIDER }}
+
+      - name: Comment plan on PR
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          PLAN_FILE: ${{ matrix.root }}/plan.txt
+          ROOT: ${{ matrix.root }}
+          PLAN_EXIT_CODE: ${{ steps.plan.outputs.plan-exit-code }}
+        with:
+          script: |
+            const fs = require('fs');
+            const root = process.env.ROOT;
+            const marker = `<!-- terraform-plan ${root} -->`;
+            const exitCode = process.env.PLAN_EXIT_CODE;
+            let plan = '(plan output is unavailable; see the workflow log)';
+            if (fs.existsSync(process.env.PLAN_FILE)) {
+              plan = fs.readFileSync(process.env.PLAN_FILE, 'utf8');
+            }
+            const maxLength = 60000;
+            let truncated = plan;
+            if (plan.length > maxLength) {
+              truncated = plan.slice(0, maxLength) + '\n... (truncated; see the workflow log for the full plan)';
+            }
+            const status = exitCode === '0' ? 'No changes' : exitCode === '2' ? 'Changes present' : 'Plan failed';
+            const body = `${marker}\n### terraform plan — \`${root}\`\n\n**${status}** (${context.sha})\n\n<details><summary>plan output</summary>\n\n\`\`\`terraform\n${truncated}\n\`\`\`\n\n</details>`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -259,6 +259,11 @@ crash.*.log
 *.tfvars
 *.tfvars.json
 
+# 例外: environments 配下の terraform.tfvars は非 secret 値（project id、region、image digest など）
+# だけを置き、version 管理する（INFRA-ADR-019）。
+# secret 値は ignore されたままの secrets.auto.tfvars（local）か TF_VAR_*（CI）で渡す。
+!infra/terraform/environments/**/terraform.tfvars
+
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
 override.tf

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 
 現在、以下のドメインの ADR が存在します。
 
-- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（14件）
+- **infra/**: GCP プロジェクト構成、Terraform 構成、実行基盤、IAM など（19件）
 - **crawler/**: クローラーの実装言語、XML パース戦略など（2件）
 
 各ドメインの詳細な一覧と運用ルールについては、[adr/README.md](adr/README.md) を参照してください。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@
 | `INFRA-ADR-016` | `infra` | GitHub Actions から crawler image を Artifact Registry へ push する | Accepted | [docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md](infra/016-github-actions-wif-and-crawler-image-push.md) |
 | `INFRA-ADR-017` | `infra` | GitHub Actions の Terraform 由来設定は ops が repository variable として書く | Accepted | [docs/adr/infra/017-github-actions-terraform-managed-variables.md](infra/017-github-actions-terraform-managed-variables.md) |
 | `INFRA-ADR-018` | `infra` | Artifact Registry の vulnerability scanning と image retention | Accepted | [docs/adr/infra/018-artifact-registry-cost-controls.md](infra/018-artifact-registry-cost-controls.md) |
+| `INFRA-ADR-019` | `infra` | GitHub Actions から terraform plan / apply する | Accepted | [docs/adr/infra/019-github-actions-terraform-plan-apply.md](infra/019-github-actions-terraform-plan-apply.md) |
 | `CRAWLER-ADR-001` | `crawler` | 論文収集クローラーの実装言語としてPythonを採用 | Accepted | [docs/adr/crawler/001-language-selection.md](crawler/001-language-selection.md) |
 | `CRAWLER-ADR-002` | `crawler` | XMLパースにdefusedxmlを採用 | Accepted | [docs/adr/crawler/002-xml-parsing-security.md](crawler/002-xml-parsing-security.md) |
 

--- a/docs/adr/infra/011-terraform-ci-for-monorepo.md
+++ b/docs/adr/infra/011-terraform-ci-for-monorepo.md
@@ -159,3 +159,4 @@ backend を無効化した init を使い、`mock_provider` と `override_data` 
 
 - [INFRA-ADR-002] Terraform 構成: ドメイン駆動モジュールとマルチプロジェクト戦略の採用
 - [INFRA-ADR-005] Terraform environments は GCP project ごとに分割する
+- [INFRA-ADR-019] GitHub Actions から terraform plan / apply する

--- a/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
+++ b/docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md
@@ -280,6 +280,7 @@ GitHub の repository variable は ops Terraform が書く（[INFRA-ADR-017](./0
 - [[INFRA-ADR-015] data は箱とし、guest IAM は依存の下流が書く](./015-guest-iam-downstream.md)
 - [[INFRA-ADR-017] GitHub Actions の Terraform 由来設定は ops が repository variable として書く](./017-github-actions-terraform-managed-variables.md)
 - [[INFRA-ADR-018] Artifact Registry の vulnerability scanning と image retention](./018-artifact-registry-cost-controls.md)
+- [[INFRA-ADR-019] GitHub Actions から terraform plan / apply する](./019-github-actions-terraform-plan-apply.md)（IAM の主キーと crawler の branch 制限を置き換える。pool / direct access は維持）
 - [Crawler Deploy workflow](../../../.github/workflows/crawler-deploy.yaml)
 - [crawler README](../../../workflows/crawler/README.md)
 - [Infrastructure README](../../../infra/README.md)

--- a/docs/adr/infra/019-github-actions-terraform-plan-apply.md
+++ b/docs/adr/infra/019-github-actions-terraform-plan-apply.md
@@ -1,0 +1,395 @@
+# INFRA-ADR-019 GitHub Actions から terraform plan / apply する
+
+## Conclusion (結論)
+
+- GitHub Actions から terraform plan / apply する。WIF は既存の pool `github-devgist` / provider `oidc` を維持する。用途の分離は provider を増やさず、custom attribute `ci_scope`（operation × environment）と IAM の `principalSet` で行う。`attribute.environment` は IAM の主キーから外す。
+- plan は same-repo PR で read-only の speculative plan を実行し、結果を PR コメントに出す。apply は protected `main` への push で dev を自動適用する。final plan は `terraform plan -out=tfplan` で保存し、`terraform apply tfplan` で確認した plan と同じ内容を適用する。
+- CI apply の対象 root は `devgist-ops` / `devgist-data/dev` / `devgist-app/dev`。`devgist-tf` と、GitHub リソースを管理する新 root `environments/github` はローカル apply に限定する。GitHub App は導入しない（作成・設定した App と `TF_GITHUB_APP_*` は削除する）。
+- apply principal は WIF pool / provider / attribute mapping、CI principal 自身の IAM、tfstate 基盤（`devgist-tf`）、GitHub リソースを変更できない。これらの差分を含む CI apply は権限不足で失敗し、手元 apply（bootstrap）となる。
+- prod は環境が未作成のため器だけ用意する。`ci_scope` の mapping には prod 条件を先に入れるが、IAM binding と workflow ファイルは prod 環境作成時に足す。
+
+## Status (ステータス)
+
+Accepted (承認済み) - 2026-08-30
+
+[INFRA-ADR-011](./011-terraform-ci-for-monorepo.md) が後続に送った plan / apply の設計である。[INFRA-ADR-016](./016-github-actions-wif-and-crawler-image-push.md) の認証モデル（GitHub 専用 pool、direct resource access、SA impersonation なし、condition は repository id）は維持する。016 の「IAM は `attribute.environment/dev`」「crawler image は branch を問わず」は本 ADR が置き換える。[INFRA-ADR-017](./017-github-actions-terraform-managed-variables.md) の「GitHub リソースは ops が書く」は、置き場を `environments/github` root に変える。「Terraform が正本の値は GitHub にベタ書きせず Terraform から書く」原則は維持する。016 / 017 本文は履歴として残す。
+
+## Context (背景・課題)
+
+### 背景
+
+Terraform CI は fmt / validate / test / tflint / trivy までである。`terraform init -backend=false` で、GCP 認証も plan も apply も無い（[INFRA-ADR-011](./011-terraform-ci-for-monorepo.md)）。
+
+GitHub Actions 用 WIF は ops の pool `github-devgist` / provider `oidc` にある。IAM は `principalSet://.../attribute.environment/dev` に crawler Artifact Registry の writer だけが付いている（[INFRA-ADR-016](./016-github-actions-wif-and-crawler-image-push.md)）。GitHub Environment `dev` は OIDC claim 用で、protection は付けない（[INFRA-ADR-017](./017-github-actions-terraform-managed-variables.md)）。
+
+このまま apply 用 write IAM を `attribute.environment/dev` に足すと、同じ Environment を使う全 workflow が write を共有する。`on: pull_request` の YAML は PR head から実行されるので、plan 用 job に `environment: dev` を書けば、緩い provider condition（repository id のみ）を通って write principal を満たせる。
+
+要件は次である。
+
+- PR と `main` の push で plan したい
+- apply は protected `main` への push だけ
+- plan と apply で principal の権限を分ける
+- 既存 WIF を増やすのではなく、principal で切る
+
+Google は GitHub のような multi-tenant IdP では attribute condition で tenant / repository を制限すること、**1 pool につき 1 provider**、**同じ IdP を重複 federation しない**ことを推奨している。用途の分岐は mapping の CEL と IAM で行う。
+
+### GitHub リソースの扱い
+
+ops root の GitHub provider リソース（Environment、repository variable）は、Actions の `GITHUB_TOKEN` では write できない（Environments の作成・更新には GitHub App / PAT の `Administration: write` が要る）。GitHub App を作って CI に載せる案を検討し、App と `TF_GITHUB_APP_*` の secret / variable まで作成したが、次の理由で却下した。
+
+- PR の YAML は PR head から実行される。repo secret の PEM は same-repo PR の workflow から参照可能で、protection なしに credential を CI に置くことになる
+- GitHub リソースの変更頻度は低く、自動化のメリットが小さい
+- 一方で再現性は欲しいので、Terraform 管理自体は続ける
+
+一般原則として、**CI にするとセキュリティ対処コストが高く、自動化のメリットが低いものはローカルで管理する**。GitHub リソースは新 root `environments/github` に分離し、plan / apply をローカルに限定する。これにより CI の workflow は GCP 認証だけを持ち、GitHub 側の credential を CI に置く問題自体が消える。
+
+### 要件と制約
+
+1. **長寿命の秘密を GitHub に置かない**
+   - JSON キーを repo secret にしない。credential config に SA impersonation を入れない。GitHub App の PEM も置かない
+2. **plan と apply の blast radius を分ける**
+   - plan principal は read-only。PR の YAML 改ざんが write に届かない
+3. **write は protected `main` に限定する**
+   - `main` は Ruleset 済み（PR 必須、required checks、up-to-date 必須、force push / delete 禁止）
+   - crawler の AR writer も同じ理由で `main` に閉じる
+4. **既存の GitHub WIF 入口を維持する**
+   - pool / provider / issuer は 016 のまま。Cursor 用 pool には触れない
+5. **CI apply の対象は ops / data / app。tf と github は載せない**
+   - state bucket を持つ `devgist-tf` と、GitHub リソースを持つ `environments/github` はローカル apply
+6. **CI apply が自分の trust boundary を書き換えられない**
+   - WIF pool / provider / attribute mapping、CI principal 自身の IAM、GitHub Ruleset の更新権限を apply principal に付けない
+7. **guest IAM の置き場は 015 の表**
+8. **静的 CI は GCP 認証なしのまま**
+   - 011 の `terraform-ci.yml` は維持する。plan / apply は別 workflow
+9. **確認した plan と apply 内容を一致させる**
+   - `terraform plan -out=tfplan` → `terraform apply tfplan`。bare `terraform apply` は使わない
+10. **PR plan と apply は時間的に一致しない**
+    - PR plan は speculative。apply 直前に `main` 上で final plan を再生成する
+
+### 比較した選択肢
+
+#### WIF の分割単位
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: plan / apply で pool または provider を増やす | 認証境界そのものを用途で物理分割したい場合 | 緩い provider が apply 用 Environment を発行できない | 同じ GitHub IdP の dual federation。Google が避ける subject collision / 同一 IdP の重複 | 非採用 |
+| Option B: GitHub Environment 名を IAM の主キーにする（現状の延長） | job の `environment:` と IAM を 1:1 にしたい場合 | 016 からの差分が小さい | PR の YAML が Environment 名を選べる。crawler と apply が `dev` を共有し得る | 非採用 |
+| Option C: 1 pool / 1 provider のまま `ci_scope` を CEL で合成する | 同じ GitHub IdP を複数 CI 用途に使う場合 | 入口は 1 つ。principal は用途ごと。claim は GitHub 署名で、YAML が `ci_scope` を名乗れない | mapping が CEL としてやや長い。`workflow_ref` は repository 名を含む | 採用 |
+
+#### write を `main` に閉じる場所
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: provider condition に `ref == refs/heads/main` を入れる | その provider 全体を main 専用にしたい場合 | token 交換時点で PR を拒否できる | PR plan が同じ provider を使えない | 非採用 |
+| Option B: `ci_scope` の合成条件に workflow / event / ref / environment を入れる | 入口は広く、用途ごとに閉じたい場合 | plan は PR を通せる。apply / crawler は main だけ write | mapping が security-critical。変更は bootstrap | 採用 |
+
+#### CI apply の対象 root
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: data / app のみ。ops は手元 | WIF と CI identity を CI から完全に隔離したい場合 | 自己権限昇格の面が狭い | ops の AR や guest IAM も毎回手元 | 非採用 |
+| Option B: ops / data / app を CI。tf は手元 | state 基盤だけ極小に残したい場合 | 日常の apply 対象が揃う。tfstate project は不変に近い | ops 同一 root に WIF がある。apply IAM で mapping 更新を禁止する必要がある | 採用 |
+| Option C: 全 root を CI | 手元 apply を無くしたい場合 | 導線が 1 つ | tfstate を CI が作り変えられる。004 の tf 保護と食い違う | 非採用 |
+
+#### ops の GitHub リソース
+
+| 選択肢 | 向いている用途 | メリット | デメリット | 今回の評価 |
+|---|---|---|---|---|
+| Option A: workflow の `GITHUB_TOKEN` で CI apply する | 追加 credential なしで済ませたい場合 | 秘密が増えない | `GITHUB_TOKEN` は Environments を write できない（GitHub App / PAT の `Administration: write` が必要）。必ず失敗する | 非採用 |
+| Option B: GitHub App を作り CI apply する | ops を丸ごと CI に載せたい場合 | GitHub リソースも自動化できる | PEM という長寿命の秘密を repo secret に置く。PR YAML から参照できる。GitHub リソースの変更頻度は低く自動化メリットが小さい | 非採用 |
+| Option C: `environments/github` root に分離しローカル apply に限定する | 再現性は Terraform で確保しつつ CI には載せない場合 | CI は GCP 認証だけを持つ。credential を CI に置く問題が消える | GitHub リソースの変更は手元 apply。state 移行（state rm + import）が要る | 採用 |
+
+### 選定観点
+
+- Google の 1 pool / 1 provider と、同一 GitHub IdP を増やさないこと
+- PR が apply / crawler の write principal を選べないこと
+- plan は PR と `main` の両方で動くこと
+- write 系は protected `main` に閉じること
+- CI が WIF mapping、CI principal 自身の IAM、tfstate 基盤、GitHub リソースを更新できないこと
+- CI 化のセキュリティコストが自動化メリットを上回るものはローカルで管理すること
+
+## Considered Options
+
+### Option A: plan / apply で WIF を増やす [却下]
+
+pool または provider を plan 用と apply 用に分ける方式。
+
+却下理由:
+
+- 同じ issuer `https://token.actions.githubusercontent.com` を二重に federation する
+- Google は 1 pool 1 provider、同じ IdP の重複を避ける
+- 016 の「この repo の GitHub Actions 入口は 1 pool」を崩す
+- 分離は IAM で足りる。足りないのは Environment 名を主キーにしたことである
+
+### Option B: GitHub Environment を GCP principal の主キーにする [却下]
+
+`dev-plan` / `dev-apply` を作り、`attribute.environment` に IAM を付ける方式。
+
+却下理由:
+
+- `environment` claim の値は job の `environment:` そのもので、`pull_request` の YAML が選べる
+- 既存 provider の condition は repository id だけなので、PR でも token 交換に成功する
+- crawler-deploy が `environment: dev` のままだと、apply を同じ principal に足した瞬間に image push job が tfstate / Cloud Run まで持つ
+
+GitHub Environment 自体は残してよい。使うのは protection / 履歴と、apply 系 `ci_scope` の合成条件の一部であり、GCP IAM のキーではない。
+
+### Option C: `ci_scope` を CEL で合成し、IAM は principalSet で分ける [採用]
+
+provider の attribute mapping で、GitHub が署名した `workflow_ref` / `event_name` / `ref` / `environment` から `attribute.ci_scope` を作る。IAM は `principalSet://.../attribute.ci_scope/<value>` に付ける。
+
+採用理由:
+
+- `ci_scope` は YAML の文字列ではなく、実行コンテキストから導出される
+- PR の `workflow_ref` は `.../terraform-plan.yml@refs/pull/N/merge` であり、apply 条件の `@refs/heads/main` かつ `event_name == push` を満たさない
+- apply の条件に `environment == "dev"` を含める。prod では `environment: prod` に required reviewers を付けることで、**approval 通過後にしか `environment=prod` の JWT が発行されず**、GitHub の承認ゲートと GCP identity が結合する
+- crawler の writer も `crawler-deploy.yaml@refs/heads/main` に閉じる。feature branch の push では `ci_scope=none` になり、condition で token 交換に失敗する
+- 既存の `google-github-actions/auth` は provider 名を変えない。workflow は `ci_scope` を渡さない
+
+### Option D: GitHub App で ops の GitHub リソースまで CI apply する [却下]
+
+GitHub App を作成し、`TF_GITHUB_APP_ID` / `TF_GITHUB_APP_INSTALLATION_ID` / `TF_GITHUB_APP_PEM_FILE` を repository secret / variable に設定して、CI から GitHub provider を App 認証で動かす方式。
+
+却下理由:
+
+- PEM は長寿命の秘密であり、「長寿命の秘密を GitHub に置かない」の要件と緊張する
+- repo secret は same-repo PR の workflow YAML から参照できる。plan を PR に載せる以上、Credential の露出面が増える
+- GitHub リソース（Environment、repository variable）は変更頻度が低く、自動化のメリットが小さい
+- セキュリティ対処コストが自動化メリットを上回るものはローカル管理にする一般原則に従う
+
+作成済みの GitHub App と `TF_GITHUB_APP_*` は削除する。GitHub リソースは `environments/github` root に移し、ローカルから個人の `GITHUB_TOKEN` で apply する（017 の手元運用を維持）。
+
+## Decision (決定事項)
+
+GitHub Actions の terraform plan / apply と crawler image push は、既存の GitHub WIF 1 組を入口にし、`attribute.ci_scope` ごとの principalSet で認可する。
+
+### 採用方針
+
+#### WIF
+
+- pool `github-devgist` / provider `oidc` / issuer `https://token.actions.githubusercontent.com` は維持する
+- `attribute.environment = assertion.environment` は外す。GitHub Environment の無い job でも、`ci_scope` が付くなら federate できる。job に Environment を付けて protection や履歴に使うのは自由だが、GCP は Environment 単体では認可しない
+- `google.subject` は `assertion.sub` のまま（監査の一意性）
+- `repository_id` / `repository_owner_id` の mapping は維持する。`workflow_ref` / `ref` / `event_name` / `environment` は合成の材料であり、IAM のキーにはしない
+- `attribute.ci_scope` は CEL の三項演算子で決める。値は URL に載るので `terraform-plan-dev` のような短い token にする。`workflow_ref` 全体を値にしない
+- `environment` は optional claim なので、CEL では `has(assertion.environment)` で guard する
+
+#### Provider condition
+
+認証境界は repository の immutable id と、既知の用途だけ通すことの AND である。
+
+```hcl
+attribute_condition = <<-EOT
+  assertion.repository_id == "1106323394" &&
+  assertion.repository_owner_id == "31652298" &&
+  attribute.ci_scope != "none"
+EOT
+```
+
+`ref` や workflow を共通 condition に入れない。入れると PR plan が死ぬ。
+
+#### `ci_scope` の合成
+
+`workflow_ref` は `OWNER/REPO/.github/workflows/FILE@REF` であり repository **名** を含む。condition が `repository_id` で repo を固定しているので、パス側は JWT の `assertion.repository` を結合し、repo 名を Terraform にベタ書きしない。rename すると `repository` と `workflow_ref` が同じ JWT で一緒に変わる。id は condition のまま。
+
+初期の対応は次である。ファイル名は workflow のパスそのものである。
+
+| `ci_scope` | 条件（概念） | IAM |
+|---|---|---|
+| `terraform-apply-dev` | `workflow_ref == assertion.repository + "/.github/workflows/terraform-apply.yml@refs/heads/main"` かつ `ref == "refs/heads/main"` かつ (`event_name == "push"` または `workflow_dispatch`) かつ `environment == "dev"` | ops / data-dev / app-dev の必要な write、対象 tfstate の read/write |
+| `terraform-plan-dev` | 同上の workflow / ref / event で environment 無し。または `event_name == "pull_request"` かつ `workflow_ref` が `assertion.repository + "/.github/workflows/terraform-plan.yml@refs/pull/"` で始まる | 全 tfstate の read、ops / data-dev / app-dev / tf の get/list と IAM policy の read。create / update / delete と IAM 変更と WIF 変更は付けない |
+| `terraform-apply-prod` | `terraform-apply-prod.yml` かつ `event_name == "workflow_dispatch"` かつ `ref == "refs/heads/main"` かつ `environment == "prod"` | prod 環境作成時に付ける。今は付けない |
+| `terraform-plan-prod` | `terraform-apply-prod.yml` かつ `workflow_dispatch` かつ `main` で environment 無し | 同上 |
+| `crawler-push-dev` | `event_name == "push"` かつ `ref == "refs/heads/main"` かつ `workflow_ref == assertion.repository + "/.github/workflows/crawler-deploy.yaml@refs/heads/main"` | crawler Artifact Registry の `roles/artifactregistry.writer` のみ |
+| `none` | 上記以外 | どの principalSet にも付けない。condition が token 交換を拒否する |
+
+合成は apply → plan → crawler → `none` の順で評価する。`contains("terraform-apply.yml")` のような部分一致は使わない。
+
+prod の plan / apply を別 workflow ファイル（`terraform-apply-prod.yml`）にするのは、`workflow_dispatch` の input は JWT claim に載らず、同じファイルでは prod 用 plan job（environment 無し）と dev 用 plan job を `ci_scope` で区別できないからである。prod の Environment 承認は apply job にだけ付け、plan job は承認なしで先に走らせて plan を確認できるようにする。
+
+fork の `pull_request` は GitHub が OIDC token を発行しない（fork では `id-token: write` が効かず `ACTIONS_ID_TOKEN_REQUEST_URL` が出ない）。plan workflow は加えて `head` repository が `github.repository` のときだけ auth する。authenticated plan は same-repo PR に限る。
+
+#### `attribute.environment` を外すこと
+
+懸念は次に限る。いずれも `ci_scope` 側で吸収する。
+
+- 移行中に mapping だけ先に変えると、旧 `attribute.environment/dev` に誰も当たらず crawler が落ちる。新 IAM の追加と mapping 切替と旧 binding 削除は **同一の手元 ops apply** にする
+- GCP は GitHub Environment の使用を強制しなくなる。protection が要るなら GitHub 側に付ける。write の可否は `ci_scope` が決める
+- job が `environment:` を付け続けるなら JWT の `sub` は従来どおり `environment:` を含む。mapping から外すだけで、claim 自体は消えない
+
+#### Workflow
+
+静的検証は `.github/workflows/terraform-ci.yml` のまま。GCP 認証を足さない。
+
+- `.github/workflows/terraform-plan.yml` — `pull_request` のみ。same-repo PR 限定。`ci_scope=terraform-plan-dev`。`terraform plan -lock=false`（state に lock 用 write を持たせない）。結果は PR コメントに upsert する。`devgist-tf` と `environments/github` は対象外
+- `.github/workflows/terraform-apply.yml` — `push` の `main` と `workflow_dispatch`（input `target` は `dev` のみ。prod は環境作成時に専用 workflow `terraform-apply-prod.yml` を足す）。root ごとに plan job（environment 無し → `terraform-plan-dev`）→ apply job（`environment: dev` → `terraform-apply-dev`）を組みにし、`data-dev` → `ops` → `app-dev` の順に `needs:` で直列にする
+- apply の「CI が pass したら」は Ruleset の required checks で担保する。merge できない commit は `main` に乗らず、apply も走らない。up-to-date 必須も設定済みなので、main に乗る内容は必ず CI 通過済みの組み合わせである
+- crawler-deploy の trigger を `main` に合わせる。feature branch では job を走らせない（走っても `ci_scope=none` で失敗する）
+
+apply 順は 015 の DAG に合わせる。plan → apply を root ごとに interleave するのは、後段 root の plan が前段 root の新しい output を remote state 経由で読むためである。先に全 root を plan してから apply すると、後段の saved plan が stale になる。
+
+#### final plan と apply の一致
+
+- plan job は `terraform plan -no-color -input=false -lock=false -out=tfplan` を実行し、`terraform show -no-color tfplan` を Actions Summary に出す
+- `tfplan` は artifact として plan job から apply job へ受け渡す。`retention-days: 1`。public repo でも artifact の download は GitHub login 必須だが、planned values / variables を含み得るので sensitive artifact として扱う
+- apply job は同じ commit を checkout し、同じ Terraform / provider version（lock file）で `terraform init` した上で `terraform apply -input=false tfplan` を実行する。bare `terraform apply` は使わない
+- PR で生成した plan artifact を merge 後の apply に流用しない
+- saved plan の apply 中に state が変わっていれば Terraform が "Saved plan is stale" で失敗する。concurrency は workflow 単位で `cancel-in-progress: false` とし、apply の並行実行と中断を防ぐ
+
+#### CI apply の対象と、CI が書き換えられないもの
+
+| root | plan | apply |
+|---|---|---|
+| `devgist-data/dev` | CI | CI |
+| `devgist-ops` | CI | CI（下記の例外あり） |
+| `devgist-app/dev` | CI | CI |
+| `devgist-tf` | しない | ローカル |
+| `environments/github` | しない | ローカル |
+
+ops は CI に載せる。ただし **apply principal に次を付けない**。
+
+- WIF pool / provider の更新（`iam.workloadIdentityPools.update` 相当。`workloadIdentityPoolViewer` 相当の read は付ける）
+- project 全体の IAM 管理（`roles/owner`、`roles/iam.securityAdmin`、`roles/resourcemanager.projectIamAdmin`）
+- CI principal 自身の IAM 変更（tfstate bucket の `setIamPolicy`、data-dev / ops / app-dev project の `setIamPolicy` は付けない）
+- GitHub Ruleset / Environment / repository variable の変更（CI は GitHub 向け credential を持たない）
+
+これらが差分に含まれる CI apply は権限不足で失敗する。その変更は手元（bootstrap）である。mapping が security-critical であるという Google の推奨に合わせる。CI apply の権限で完結する差分だけが CI で通る、という境界にする。
+
+#### `environments/github` root
+
+- GitHub provider のリソース（`github_repository_environment`、`github_actions_variable`）を ops から移す。値は ops の `terraform_remote_state` から読む（006）
+- state bucket は `haru256-devgist-github-tfstate`。`devgist-tf` の `tfstate_gcp_project_ids` に `haru256-devgist-github` を足して tf を apply してから使う
+- 認証はローカルの `GITHUB_TOKEN`（017 の手元運用）。GitHub App は使わない
+- 移行は ops で `terraform state rm` してから github root で `terraform import` する
+- この root は `providers.tf` を持つため静的 CI（fmt / validate / tflint / test）の対象にはなるが、plan / apply の対象からは除外する
+
+#### IAM の置き場（015）
+
+| identity | resource | 書く root |
+|---|---|---|
+| GitHub `ci_scope`（ops の WIF） | tfstate buckets（tf project） | ops |
+| 同上 | tf project の project ロール | ops |
+| 同上 | data-dev のリソース・project ロール | ops |
+| 同上 | ops 同一 root の AR など | ops |
+| 同上 | app-dev の project ロール・crawler SA の actAs | app-dev |
+
+ロールは resource-level を優先し、だめなら project の predefined、その次に custom role である。`roles/editor` は付けない。
+
+resource の IAM policy の read（`getIamPolicy`）は、predefined の read-only role では bucket / AR repository 分を賄えない（`roles/viewer` は project の `getIamPolicy` 系を含むが、`storage.buckets.getIamPolicy` や `artifactregistry.repositories.getIamPolicy` は含まない）。plan が `_*_iam_member` を refresh するにはこれらが要るので、次の custom role を各 resource 側の root で定義する。
+
+| custom role | 定義する root | permissions | 付与先 |
+|---|---|---|---|
+| `tfstateReader` | `devgist-tf` | `storage.buckets.get` / `storage.buckets.getIamPolicy` / `storage.objects.get` / `storage.objects.list` | 全 tfstate bucket × plan-dev / apply-dev |
+| `datalakeIamReader` | `devgist-data/dev` | `storage.buckets.get` / `storage.buckets.getIamPolicy` | datalake bucket × plan-dev |
+| `arRepoIamReader` | `devgist-ops` | `artifactregistry.repositories.get` / `artifactregistry.repositories.getIamPolicy` | crawler AR repository × plan-dev |
+
+custom role の定義変更は CI apply では通らない（apply principal に `iam.roles.update` を付けない）。定義の作成・変更は bootstrap である。
+
+plan は上記 read に加えて各 project の `roles/viewer` と `roles/iam.securityReviewer`（project の `getIamPolicy` と SA / custom role / WIF pool の read）。apply は対象 deploy bucket の `roles/storage.objectUser` と、app-dev / data-dev / ops の必要な mutation（`run.admin`、`storage.admin`、`artifactregistry.admin`、`iam.serviceAccountAdmin`、`serviceusage.serviceUsageAdmin` など）に、crawler SA への `roles/iam.serviceAccountUser` を足す。crawler-push は AR writer だけである。
+
+#### tfvars
+
+gitignore の `*.tfvars` のままだと CI は plan も apply もできない。空の値で ops を apply すると `cursor_oidc_subjects` が空になり、Cursor の GCS IAM が消える。
+
+- 非 secret（`gcp_project_id`、region、`crawler_image` digest、conference 名など）は `environments/**/terraform.tfvars` に限り version 管理する。gitignore にそのパスの例外を置く。それ以外の `*.tfvars` は引き続き ignore する
+- 人が特定される値（`cursor_oidc_subjects`、`service_account_user_emails`）は commit しない。ローカルは auto-load される `secrets.auto.tfvars`（ignore 済み）に書き、CI は GitHub Actions の repository secret から `TF_VAR_*` で渡す
+- これらの variable から `default = []` を外す。未設定なら terraform が "No value for required variable" で落ちるため、値が無いまま apply して grant を消す事故を防ぐ
+- `crawler_image` は variable を維持し、値は committed tfvars に置く。image の更新は「build（crawler-deploy が main で push）→ digest を tfvars に書き換える infra PR → merge で apply」の 2 PR 運用とする。digest を書き換える PR の自動作成 CI は別タスク（issue #60 の後続）とする
+
+### 初期構成
+
+```
+GitHub OIDC
+    │
+    ▼
+github-devgist / oidc
+    │  condition: repository_id + owner_id + ci_scope != "none"
+    │  mapping: ci_scope を workflow_ref + event_name + ref + environment から合成
+    │           attribute.environment は置かない
+    │
+    ├─ terraform-plan.yml
+    │    PR (same-repo)
+    │    → terraform-plan-dev → state/GCP READ → PR コメント
+    │
+    ├─ terraform-apply.yml
+    │    push main / workflow_dispatch(target=dev)
+    │    → plan job (terraform-plan-dev) → artifact → apply job (environment: dev, terraform-apply-dev)
+    │    → data-dev → ops → app-dev の直列
+    │
+    └─ crawler-deploy.yaml
+         push main のみ
+         → crawler-push-dev → AR writer
+
+ローカル / bootstrap
+├─ devgist-tf（tfstate bucket、tfstateReader custom role）
+├─ environments/github（GitHub Environment / repository variable）
+├─ WIF mapping と pool/provider の変更
+└─ CI principal の IAM grant の作成・変更
+```
+
+### 再検討条件
+
+- federated identity 非対応 API が出て、その API だけ SA impersonation に寄せる場合
+- prod を足すとき。`terraform-apply-prod.yml` を作り、prod の principalSet に IAM を付ける。GitHub Environment `prod`（required reviewers 付き）は `environments/github` root に足す。個人開発なので deployment 開始者本人が承認する前提で `Prevent self-review` は付けない
+- リポジトリ rename。`repository_id` は不変。`workflow_ref` は `assertion.repository` 結合なので通常は追従する。claim の形が変わったときだけ mapping を直す
+- collaborator を増やすとき。same-repo PR から repository secret が参照できるため、`CURSOR_OIDC_SUBJECTS` / `SERVICE_ACCOUNT_USER_EMAILS` の置き場と plan workflow の権限を見直す
+- Terraform root 数が増え、全 root の直列 apply が重い場合
+- tfvars に secret 値が入る見込みが出た場合。tfplan artifact の中身も見直す
+
+## Consequences (結果・影響)
+
+### Positive (メリット)
+
+- WIF 入口は 1 つのまま、plan / apply / crawler の IAM が分かれる
+- PR が Environment 名を書いても apply principal を満たせない
+- write は protected `main` に閉じる。crawler の AR writer も同じ
+- 011 の静的 CI は GCP なしのまま
+- tfstate project と GitHub リソースを CI の日常変更から外せる
+- CI は GCP 向け credential だけを持ち、GitHub 向けの長寿命の秘密を CI に置かない
+- 確認した saved plan と apply 内容が一致する
+
+### Negative (デメリット)
+
+- same-repo PR の `.tf` は plan principal の read で実行される。state や resource 識別子の読み出し、`local-exec` は残る
+- `terraform-apply.yml` が `main` に入ったあとの中身は、WIF から見ると正当な apply である。中身のレビューは Ruleset 頼み
+- mapping 変更、CI principal の IAM 変更、GitHub リソース、`devgist-tf` は手元が残る
+- crawler は feature branch から image を push できない（016 からの行動変）
+- `workflow_ref` はファイルパスに結合する。workflow のリネームは mapping の更新（手元 apply）が要る
+- GitHub リソースの root 分離で state 移行（state rm + import）が一度だけ要る
+
+### Risks / Future Review (将来の課題)
+
+- apply principal が project IAM admin を後から付与されると、自分で WIF を緩められる。ロール追加の PR を見る
+- plan 結果を public の PR コメントに出す。識別子は公開されるが secret は含めない。Actions log も login 済みユーザーには見えるので、秘匿性はコメントでも log でも変わらない
+- tfplan artifact は login 必須だが sensitive 扱いとし、`retention-days: 1` にする。tfvars に secret が入る見込みが出たら再検討する
+- 直列 apply の途中失敗で data だけ新しい、があり得る。再実行で揃える
+- IAM ロールの初期セットは実際の CI plan / apply で不足が出たら権限エラーのメッセージに従って足す。初回の CI 実行で調整する
+- GitHub App を再導入したくなった場合は、本 ADR の Option D の却下理由を再評価する
+
+## Next Steps
+
+1. `devgist-tf` の `tfstate_gcp_project_ids` に `haru256-devgist-github` を足し、`tfstateReader` custom role と `tf_project_id` output を追加して、ローカルで tf を apply する
+2. `environments/github` root を作り、ops から GitHub リソースを移す（ops で `terraform state rm` → github root で `terraform import`）。ローカルで github root を apply する
+3. ops の GitHub WIF mapping に `ci_scope` を足し、condition に `ci_scope != "none"` を足し、`attribute.environment` を外す。新 principalSet の IAM を足してから、同一の手元 apply で旧 `attribute.environment/dev` を外す
+4. plan / apply principal の guest IAM を 015 の表どおり ops と app-dev に書く。tfstate bucket の IAM も含める。data-dev に `datalakeIamReader`、ops に `arRepoIamReader` を定義する。ローカルで data → ops → app の順に apply する
+5. 非 secret tfvars の commit 例外を入れ、allowlist を `secrets.auto.tfvars` に移す。repository secret `CURSOR_OIDC_SUBJECTS` / `SERVICE_ACCOUNT_USER_EMAILS` を作る。作成済みの GitHub App と `TF_GITHUB_APP_*` を削除する
+6. `terraform-plan.yml` と `terraform-apply.yml` を追加する。crawler-deploy の trigger を `main` にする
+7. ops の tftest を `ci_scope` に更新する。plan / apply 対象 root の検出には 011 の root 検出に除外フィルタを足したものを使う
+8. merge 後、初回の CI plan / apply が通ることを確認し、権限不足があればロールを足す（手元 apply を挟む）
+
+## Related Documents
+
+- [[INFRA-ADR-004] Terraform State Project と Ops Project を分離する](./004-separate-tf-and-ops-projects.md)
+- [[INFRA-ADR-006] Cross-project Terraform output 共有戦略](./006-cross-project-output-sharing.md)
+- [[INFRA-ADR-010] Cloud Run Job の管理責務を Terraform に集約する](./010-cloud-run-job-management.md)
+- [[INFRA-ADR-011] Terraform monorepo における CI 対象検出と検証方針](./011-terraform-ci-for-monorepo.md)
+- [[INFRA-ADR-015] data は箱とし、guest IAM は依存の下流が書く](./015-guest-iam-downstream.md)
+- [[INFRA-ADR-016] GitHub Actions から crawler image を Artifact Registry へ push する](./016-github-actions-wif-and-crawler-image-push.md)
+- [[INFRA-ADR-017] GitHub Actions の Terraform 由来設定は ops が repository variable として書く](./017-github-actions-terraform-managed-variables.md)（置き場は本 ADR が `environments/github` に変える）
+- [Terraform CI](../../../.github/workflows/terraform-ci.yml)
+- [Crawler Deploy workflow](../../../.github/workflows/crawler-deploy.yaml)
+- [Infrastructure README](../../../infra/README.md)
+- [issue #60](https://github.com/haru-256/devgist/issues/60)
+- [Best practices for using Workload Identity Federation](https://docs.cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation)
+- [Workload Identity Federation（attribute mapping / principalSet）](https://docs.cloud.google.com/iam/docs/workload-identity-federation)
+- [GitHub OIDC claims](https://docs.github.com/en/actions/reference/security/oidc)
+- [Permissions in a forked repository](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository)

--- a/infra/README.md
+++ b/infra/README.md
@@ -25,6 +25,7 @@
 - `INFRA-ADR-016`: [docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md](../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md)
 - `INFRA-ADR-017`: [docs/adr/infra/017-github-actions-terraform-managed-variables.md](../docs/adr/infra/017-github-actions-terraform-managed-variables.md)
 - `INFRA-ADR-018`: [docs/adr/infra/018-artifact-registry-cost-controls.md](../docs/adr/infra/018-artifact-registry-cost-controls.md)
+- `INFRA-ADR-019`: [docs/adr/infra/019-github-actions-terraform-plan-apply.md](../docs/adr/infra/019-github-actions-terraform-plan-apply.md)
 
 このディレクトリ配下の `infra/docs/adr/` は互換性維持のための参照パスであり、正本は [docs/adr/](../docs/adr/) 側です。
 
@@ -101,10 +102,14 @@ graph LR
 3. `devgist-ops`
    - `Artifact Registry`、Cursor 用 WIF、GitHub Actions 用 WIF を作成する
    - Cursor Cloud の federated principal へ data-dev datalake の `objectViewer` / `objectCreator` を付与する
-   - GitHub Actions の federated principal へ crawler Artifact Registry の writer を付与する
+   - GitHub Actions の CI principal（`attribute.ci_scope`）へ crawler Artifact Registry の writer と plan / apply 用の IAM を付与する（[INFRA-ADR-019](../docs/adr/infra/019-github-actions-terraform-plan-apply.md)）
 4. `devgist-app/dev`
    - `terraform_remote_state` で `ops/data` の outputs を参照しながら app 側 compute を作成する
    - crawler SA へ同じ datalake の読書きを付与する
+5. `github`（ローカルのみ）
+   - GitHub Environment / repository variable を書く。`ops` の outputs を `terraform_remote_state` で参照する
+
+`main` への merge 後は `devgist-data/dev` → `devgist-ops` → `devgist-app/dev` が CI で自動 apply される（[INFRA-ADR-019](../docs/adr/infra/019-github-actions-terraform-plan-apply.md)）。`devgist-tf` と `github` は CI に載せず、ローカルで apply する。
 
 ### Notes
 
@@ -112,6 +117,6 @@ graph LR
 - `devgist-app/dev` は `devgist-ops` と `devgist-data/dev` の outputs を `terraform_remote_state` で参照する
 - secret は Terraform outputs では渡さず、`GCP Secret Manager` を app runtime から参照する
 - 旧 `environments/crawler` は legacy 扱いで、最終的には `ops/app/data` 側へ整理する
-- Cursor Cloud の subject allowlist（`cursor_oidc_subjects`）は ops の gitignore 済み `terraform.tfvars` に書く。空なら datalake IAM member が付かない
-- Cursor 用 WIF は federated principal への direct resource access である。GitHub Actions 用 WIF も direct resource access だが、pool は分ける（[INFRA-ADR-016](../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md)）。初期 IAM は crawler Artifact Registry の writer のみ。terraform apply の CI はまだ無い
-- GitHub Actions の `workload_identity_provider` と crawler image の `REPO_URL` / `IMAGE_NAME` は、ops Terraform が GitHub の repository variable として書く（[INFRA-ADR-017](../docs/adr/infra/017-github-actions-terraform-managed-variables.md)）
+- Cursor Cloud の subject allowlist（`cursor_oidc_subjects`）は ops の gitignore 済み `secrets.auto.tfvars` に書く。空なら datalake IAM member が付かない
+- Cursor 用 WIF は federated principal への direct resource access である。GitHub Actions 用 WIF も direct resource access だが、pool は分ける（[INFRA-ADR-016](../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md)）。GitHub Actions の認可は `attribute.ci_scope` 単位（[INFRA-ADR-019](../docs/adr/infra/019-github-actions-terraform-plan-apply.md)）。terraform plan / apply の CI は 019 を参照
+- GitHub Actions の `workload_identity_provider` と crawler image の `REPO_URL` / `IMAGE_NAME` は、`environments/github` root の Terraform が GitHub の repository variable として書く（[INFRA-ADR-017](../docs/adr/infra/017-github-actions-terraform-managed-variables.md)。置き場は 019 が ops から github root に変えた）

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -50,15 +50,22 @@ infra/terraform/
 │   │   ├── terraform.tfvars
 │   │   ├── variables.tf
 │   │   └── tests/
-│   └── devgist-tf/
+│   ├── devgist-tf/
+│   │   ├── Makefile
+│   │   ├── backend.tf
+│   │   ├── config.gcs.tfbackend
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── terraform.tfvars
+│   │   └── variables.tf
+│   └── github/
 │       ├── Makefile
 │       ├── backend.tf
 │       ├── config.gcs.tfbackend
 │       ├── main.tf
-│       ├── outputs.tf
 │       ├── providers.tf
-│       ├── terraform.tfvars
-│       └── variables.tf
+│       └── tests/
 ├── modules/
 │   ├── artifact_registry/
 │   │   ├── main.tf
@@ -106,9 +113,10 @@ make/
 GCP project ごとに root module を配置し、必要に応じて `dev/` などの環境サブディレクトリを切ります。
 
 - `devgist-tf/`: Terraform state 管理用 project の root module
-- `devgist-ops/`: Artifact Registry、Cursor 用 WIF、GitHub Actions 用 WIF、GitHub Environment / repository variable、共通 Service Account などの運用基盤 project の root module
+- `devgist-ops/`: Artifact Registry、Cursor 用 WIF、GitHub Actions 用 WIF、GitHub Actions CI principal の IAM、共通 Service Account などの運用基盤 project の root module
 - `devgist-data/dev/`: 開発環境の data project 用 root module
 - `devgist-app/dev/`: 開発環境の app project 用 root module
+- `github/`: GitHub Environment / repository variable を管理する root module。GCP project を持たない。plan / apply はローカル限定（[INFRA-ADR-019](../../docs/adr/infra/019-github-actions-terraform-plan-apply.md)）
 
 ### `modules/`
 複数の環境で再利用する module を配置します。
@@ -132,7 +140,8 @@ GCP project ごとに root module を配置し、必要に応じて `dev/` な�
 - module の追加・更新は `modules/` 配下に集約し、root module 側で呼び出します。
 - `terraform.tfstate` は環境ごとの状態を保持します。リモート backend を使う場合は `backend.tf` で設定します。
 - Cursor Cloud 用 WIF（pool `cursor` / provider `oidc`）は `devgist-ops` で定義する。datalake への `objectViewer` / `objectCreator` は依存の下流（ops）が federated principal に直接付与する（[INFRA-ADR-015](../../docs/adr/infra/015-guest-iam-downstream.md)）。apply 順は data → ops → app。`cursor_wif_audience` は後続の OIDC mint で使う。credential config に SA impersonation は入れない。
-- GitHub Actions 用 WIF（pool `github-devgist` / provider `oidc`）も `devgist-ops` で定義する。issuer は GitHub。crawler Artifact Registry への writer は ops 同一 root が federated principalSet に直接付与する（[INFRA-ADR-016](../../docs/adr/infra/016-github-actions-wif-and-crawler-image-push.md)）。GitHub Environment `dev` と repository variable（`GCP_GITHUB_WIF_PROVIDER`、`CRAWLER_REPO_URL`、`CRAWLER_IMAGE_NAME`）も ops が書く（[INFRA-ADR-017](../../docs/adr/infra/017-github-actions-terraform-managed-variables.md)）。apply 時は `GITHUB_TOKEN` が要る。credential config に SA impersonation は入れない。terraform apply の CI はまだ無い。
+- GitHub Actions 用 WIF（pool `github-devgist` / provider `oidc`）も `devgist-ops` で定義する。issuer は GitHub。IAM の identity class は `attribute.ci_scope`（plan / apply / crawler）である（[INFRA-ADR-019](../../docs/adr/infra/019-github-actions-terraform-plan-apply.md)）。crawler Artifact Registry への writer は `crawler-push-dev` に直接付与する。GitHub Environment `dev` と repository variable（`GCP_GITHUB_WIF_PROVIDER`、`CRAWLER_REPO_URL`、`CRAWLER_IMAGE_NAME`）は `environments/github` root が書く（[INFRA-ADR-017](../../docs/adr/infra/017-github-actions-terraform-managed-variables.md)。置き場は 019 が ops から github root に変えた）。GitHub リソースの write と WIF mapping の変更は手元。credential config に SA impersonation は入れない。terraform plan / apply の CI は 019。
+- `environments/**/terraform.tfvars` は非 secret 値に限り version 管理する（019）。secret 値（`cursor_oidc_subjects`、`service_account_user_emails`）はローカルでは gitignore 済みの `secrets.auto.tfvars`、CI では repository secret 経由の `TF_VAR_*` で渡す。これらの variable に default はなく、未設定では plan / apply が失敗する。
 
 ## for_each を使う場合の outputs 出力
 

--- a/infra/terraform/environments/.gitignore
+++ b/infra/terraform/environments/.gitignore
@@ -1,2 +1,3 @@
 .env.dev
-terraform.tfvars
+# terraform.tfvars は非 secret 値に限り version 管理する（INFRA-ADR-019）。
+# secret 値（cursor_oidc_subjects など）は secrets.auto.tfvars に書く（*.tfvars は root の .gitignore で ignore 済み）

--- a/infra/terraform/environments/devgist-app/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-app/dev/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.18.0"
-  constraints = "~> 7.18.0"
+  constraints = ">= 3.53.0, ~> 7.18.0, < 8.0.0"
   hashes = [
     "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "h1:p1/8oF64IGjiI47qa4OlsagwgtqGZUT5UU0Vtjv9g9M=",
     "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
     "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
     "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.18.0"
   constraints = "~> 7.18.0"
   hashes = [
+    "h1:qf+lQn4pQLcsIzX47cjYzTGA1X9TOaY+MQapdCX0OjQ=",
     "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
     "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
     "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.13.1"
   hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
     "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
     "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
     "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",

--- a/infra/terraform/environments/devgist-app/dev/main.tf
+++ b/infra/terraform/environments/devgist-app/dev/main.tf
@@ -16,6 +16,12 @@ locals {
       repository_id = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_id
     }
   }
+
+  # INFRA-ADR-019: GitHub Actions CI の認可単位（operation × environment）
+  ci_scope_terraform_plan_dev  = "terraform-plan-dev"
+  ci_scope_terraform_apply_dev = "terraform-apply-dev"
+
+  github_ci_principal_set_prefix = "principalSet://iam.googleapis.com/projects/${data.terraform_remote_state.ops.outputs.ops_project_number}/locations/global/workloadIdentityPools/${data.terraform_remote_state.ops.outputs.github_wif_pool_id}/attribute.ci_scope"
 }
 
 data "google_project" "project" {
@@ -93,6 +99,45 @@ resource "google_storage_bucket_iam_member" "crawler" {
   bucket = data.terraform_remote_state.data_dev.outputs.datalake_bucket_name
   role   = each.value
   member = module.service_accounts.members["crawler"]
+}
+
+# ============================================================
+# GitHub Actions CI principals（INFRA-ADR-019）
+# identity=ops × resource=app は下流の app が書く（INFRA-ADR-015）。
+# これらの grant 自体の変更（setIamPolicy）は CI principal に付けない。
+# 差分が出たら CI apply は権限不足で失敗し、手元 apply（bootstrap）となる。
+# ============================================================
+
+resource "google_project_iam_member" "ci_plan_app_dev" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+  ])
+
+  project = data.google_project.project.project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
+}
+
+resource "google_project_iam_member" "ci_apply_app_dev" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/run.admin",                      # Cloud Run Job の作成・更新・削除
+    "roles/iam.serviceAccountAdmin",        # crawler SA の作成・削除と SA IAM
+    "roles/serviceusage.serviceUsageAdmin", # API 有効化
+  ])
+
+  project = data.google_project.project.project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
+}
+
+# apply が Cloud Run Job の実行 SA として crawler SA を指定するための actAs
+resource "google_service_account_iam_member" "ci_apply_crawler_sa_user" {
+  service_account_id = module.service_accounts.names["crawler"]
+  role               = "roles/iam.serviceAccountUser"
+  member             = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
 }
 
 # Crawler用のCloud Run Job の作成

--- a/infra/terraform/environments/devgist-app/dev/terraform.tfvars
+++ b/infra/terraform/environments/devgist-app/dev/terraform.tfvars
@@ -1,0 +1,8 @@
+# 非 secret 値のみ。service_account_user_emails は
+# secrets.auto.tfvars（local、gitignore 済み）か TF_VAR_*（CI）で渡す（INFRA-ADR-019）
+gcp_project_id     = "haru256-devgist-app-dev"
+gcp_default_region = "us-central1"
+
+# crawler image の digest。crawler-deploy が main で push した image に合わせ、
+# digest を書き換える infra PR で更新する（INFRA-ADR-019）
+crawler_image = "us-central1-docker.pkg.dev/haru256-devgist-ops/crawler/crawler@sha256:bdb4626f3a6352d93b33ee39846610151e8060165b99921a1d0877f57ae314b4"

--- a/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
+++ b/infra/terraform/environments/devgist-app/dev/tests/variables.tftest.hcl
@@ -5,6 +5,8 @@ override_data {
   values = {
     outputs = {
       ops_project_id                                = "mock-ops-project"
+      ops_project_number                            = "123456789"
+      github_wif_pool_id                            = "github-devgist"
       crawler_artifact_registry_repository_id       = "mock-crawler-repo"
       crawler_artifact_registry_repository_location = "us-central1"
     }
@@ -22,9 +24,10 @@ override_data {
 }
 
 variables {
-  gcp_project_id     = "app-dev"
-  gcp_default_region = "us-central1"
-  crawler_image      = "us-central1-docker.pkg.dev/ops/crawler/crawler@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  gcp_project_id              = "app-dev"
+  gcp_default_region          = "us-central1"
+  crawler_image               = "us-central1-docker.pkg.dev/ops/crawler/crawler@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  service_account_user_emails = []
 }
 
 run "accept_single_conference_name" {

--- a/infra/terraform/environments/devgist-app/dev/variables.tf
+++ b/infra/terraform/environments/devgist-app/dev/variables.tf
@@ -10,8 +10,7 @@ variable "gcp_default_region" {
 
 variable "service_account_user_emails" {
   type        = set(string)
-  description = "Email addresses of users allowed to attach / actAs managed service accounts."
-  default     = []
+  description = "Email addresses of users allowed to attach / actAs managed service accounts. No default on purpose: set it in the gitignored secrets.auto.tfvars (local) or TF_VAR_service_account_user_emails (CI) so that an unset value fails instead of wiping grants (INFRA-ADR-019)."
 
   validation {
     condition = alltrue([

--- a/infra/terraform/environments/devgist-data/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-data/dev/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "~> 7.18.0"
   hashes = [
     "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "h1:p1/8oF64IGjiI47qa4OlsagwgtqGZUT5UU0Vtjv9g9M=",
     "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
     "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
     "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.18.0"
   constraints = "~> 7.18.0"
   hashes = [
+    "h1:qf+lQn4pQLcsIzX47cjYzTGA1X9TOaY+MQapdCX0OjQ=",
     "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
     "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
     "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.13.1"
   hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
     "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
     "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
     "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",

--- a/infra/terraform/environments/devgist-data/dev/main.tf
+++ b/infra/terraform/environments/devgist-data/dev/main.tf
@@ -2,6 +2,7 @@ locals {
   # このTerraform構成で必要な全APIをリスト化
   required_services = [
     "storage.googleapis.com", # GCS
+    "iam.googleapis.com",     # custom role 用
   ]
 }
 
@@ -26,4 +27,22 @@ module "data_platform" {
   gcp_project_id           = data.google_project.project.project_id
   datalake_bucket_location = var.gcp_default_region
   depends_on               = [module.required_project_services]
+}
+
+# GitHub Actions CI の plan が datalake bucket の IAM member（cursor / crawler の grant）を
+# refresh するための read-only custom role（INFRA-ADR-019）。
+# predefined の read-only role には storage.buckets.getIamPolicy が無い。
+# bucket への grant は ops が書く（INFRA-ADR-015）。この role の定義変更は bootstrap
+# （CI の apply principal には iam.roles.update を付けない）
+resource "google_project_iam_custom_role" "datalake_iam_reader" {
+  project     = data.google_project.project.project_id
+  role_id     = "datalakeIamReader"
+  title       = "Datalake bucket IAM reader"
+  description = "Read-only access to the datalake bucket IAM policy for terraform plan (INFRA-ADR-019)"
+  permissions = [
+    "storage.buckets.get",
+    "storage.buckets.getIamPolicy",
+  ]
+
+  depends_on = [module.required_project_services]
 }

--- a/infra/terraform/environments/devgist-data/dev/terraform.tfvars
+++ b/infra/terraform/environments/devgist-data/dev/terraform.tfvars
@@ -1,0 +1,3 @@
+# 非 secret 値のみ（INFRA-ADR-019）
+gcp_project_id     = "haru256-devgist-data-dev"
+gcp_default_region = "us-central1"

--- a/infra/terraform/environments/devgist-ops/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-ops/.terraform.lock.hcl
@@ -62,26 +62,3 @@ provider "registry.terraform.io/hashicorp/time" {
     "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
   ]
 }
-
-provider "registry.terraform.io/integrations/github" {
-  version     = "6.12.1"
-  constraints = "~> 6.12.0"
-  hashes = [
-    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
-    "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
-    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
-    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
-    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
-    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
-    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
-    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
-    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
-    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
-    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
-    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
-    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
-    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
-    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
-    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
-  ]
-}

--- a/infra/terraform/environments/devgist-ops/main.tf
+++ b/infra/terraform/environments/devgist-ops/main.tf
@@ -3,6 +3,28 @@ locals {
   github_wif_pool_id      = "github-devgist"
   github_repository_owner = "haru-256"
   github_repository_name  = "devgist"
+
+  # INFRA-ADR-019: GitHub Actions CI の認可単位（operation × environment）
+  ci_scope_terraform_plan_dev  = "terraform-plan-dev"
+  ci_scope_terraform_apply_dev = "terraform-apply-dev"
+  ci_scope_crawler_push_dev    = "crawler-push-dev"
+
+  github_ci_principal_set_prefix = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${local.github_wif_pool_id}/attribute.ci_scope"
+
+  # CI apply が state を read/write する root の tfstate bucket キー
+  # （devgist-tf の tfstate_gcp_project_ids の要素）。tf 自身と github root の state は CI に載せない
+  ci_deploy_state_bucket_keys = toset([
+    "haru256-devgist-ops",
+    "haru256-devgist-data-dev",
+    "haru256-devgist-app-dev",
+  ])
+
+  tfstate_buckets        = data.terraform_remote_state.tf.outputs.tfstate_buckets
+  all_tfstate_bucket_ids = toset([for bucket in local.tfstate_buckets : bucket.bucket_id])
+  ci_deploy_state_bucket_ids = toset([
+    for bucket in local.tfstate_buckets : bucket.bucket_id
+    if contains(local.ci_deploy_state_bucket_keys, bucket.project_id)
+  ])
 }
 
 data "google_project" "project" {
@@ -15,6 +37,15 @@ data "terraform_remote_state" "data_dev" {
 
   config = {
     bucket = "haru256-devgist-data-dev-tfstate"
+  }
+}
+
+# tfstate bucket の識別子と tf project id を借りる。tf は最上流なので循環しない（INFRA-ADR-015 / INFRA-ADR-019）
+data "terraform_remote_state" "tf" {
+  backend = "gcs"
+
+  config = {
+    bucket = "haru256-devgist-tf-tfstate"
   }
 }
 
@@ -68,7 +99,7 @@ module "cursor_wif" {
   depends_on = [module.required_project_services]
 }
 
-# INFRA-ADR-016
+# INFRA-ADR-016（認証モデル）/ INFRA-ADR-019（ci_scope による認可）
 module "github_wif" {
   source = "../../modules/workload_identity_oidc"
 
@@ -78,54 +109,221 @@ module "github_wif" {
   issuer_uri  = "https://token.actions.githubusercontent.com"
   description = "OIDC federation for GitHub Actions"
 
+  # ci_scope は GitHub が署名した claim から合成する。workflow の YAML が名乗る文字列ではない。
+  # environment は optional claim なので has() で guard する。
+  # apply 系は environment も条件に含め、GitHub Environment の protection（prod の承認）と identity を結合する。
   attribute_mapping = {
     "google.subject"                = "assertion.sub"
     "attribute.repository_id"       = "assertion.repository_id"
     "attribute.repository_owner_id" = "assertion.repository_owner_id"
-    "attribute.environment"         = "assertion.environment"
+    "attribute.ci_scope"            = <<-EOT
+      assertion.workflow_ref == assertion.repository + "/.github/workflows/terraform-apply.yml@refs/heads/main" &&
+      assertion.event_name == "push" &&
+      assertion.ref == "refs/heads/main" &&
+      has(assertion.environment) && assertion.environment == "dev"
+        ? "terraform-apply-dev"
+      : assertion.workflow_ref == assertion.repository + "/.github/workflows/terraform-apply.yml@refs/heads/main" &&
+        assertion.event_name == "workflow_dispatch" &&
+        assertion.ref == "refs/heads/main" &&
+        has(assertion.environment) && assertion.environment == "dev"
+        ? "terraform-apply-dev"
+      : assertion.workflow_ref == assertion.repository + "/.github/workflows/terraform-apply.yml@refs/heads/main" &&
+        (assertion.event_name == "push" || assertion.event_name == "workflow_dispatch") &&
+        assertion.ref == "refs/heads/main" &&
+        !has(assertion.environment)
+        ? "terraform-plan-dev"
+      : assertion.event_name == "pull_request" &&
+        assertion.workflow_ref.startsWith(assertion.repository + "/.github/workflows/terraform-plan.yml@refs/pull/")
+        ? "terraform-plan-dev"
+      : assertion.workflow_ref == assertion.repository + "/.github/workflows/terraform-apply-prod.yml@refs/heads/main" &&
+        assertion.event_name == "workflow_dispatch" &&
+        assertion.ref == "refs/heads/main" &&
+        has(assertion.environment) && assertion.environment == "prod"
+        ? "terraform-apply-prod"
+      : assertion.workflow_ref == assertion.repository + "/.github/workflows/terraform-apply-prod.yml@refs/heads/main" &&
+        assertion.event_name == "workflow_dispatch" &&
+        assertion.ref == "refs/heads/main" &&
+        !has(assertion.environment)
+        ? "terraform-plan-prod"
+      : assertion.workflow_ref == assertion.repository + "/.github/workflows/crawler-deploy.yaml@refs/heads/main" &&
+        assertion.event_name == "push" &&
+        assertion.ref == "refs/heads/main"
+        ? "crawler-push-dev"
+      : "none"
+    EOT
   }
 
   attribute_condition = <<-EOT
     assertion.repository_id == "1106323394" &&
-    assertion.repository_owner_id == "31652298"
+    assertion.repository_owner_id == "31652298" &&
+    attribute.ci_scope != "none"
   EOT
 
   depends_on = [module.required_project_services]
 }
 
-# GitHub Actions → （INFRA-ADR-016）。置き場は ops 同一 root（INFRA-ADR-015）
-resource "google_artifact_registry_repository_iam_member" "github_oidc_dev" {
+# crawler Artifact Registry の writer は crawler-push-dev に限る（INFRA-ADR-019）。
+# 置き場は ops 同一 root（INFRA-ADR-015）
+resource "google_artifact_registry_repository_iam_member" "crawler_push_dev" {
   project    = data.google_project.project.project_id
   location   = module.artifact_registries["crawler"].location
   repository = module.artifact_registries["crawler"].repository_id
   role       = "roles/artifactregistry.writer"
-  member     = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${local.github_wif_pool_id}/attribute.environment/dev"
+  member     = "${local.github_ci_principal_set_prefix}/${local.ci_scope_crawler_push_dev}"
 
   depends_on = [module.github_wif]
 }
 
-# GitHub Actions の Terraform 由来設定（INFRA-ADR-017）
-resource "github_repository_environment" "dev" {
-  repository  = local.github_repository_name
-  environment = "dev"
+# 016 からのリネーム（member は attribute.environment/dev から attribute.ci_scope/crawler-push-dev へ）
+moved {
+  from = google_artifact_registry_repository_iam_member.github_oidc_dev
+  to   = google_artifact_registry_repository_iam_member.crawler_push_dev
 }
 
-resource "github_actions_variable" "gcp_github_wif_provider" {
-  repository    = local.github_repository_name
-  variable_name = "GCP_GITHUB_WIF_PROVIDER"
-  value         = module.github_wif.provider_name
+# ============================================================
+# GitHub Actions CI principals（INFRA-ADR-019）
+# ci_scope ごとの principalSet に direct resource access で付与する。
+# plan は read-only、apply は deploy 対象 root の write。
+# これらの grant 自体の変更（setIamPolicy）は CI principal に付けない。
+# 差分が出たら CI apply は権限不足で失敗し、手元 apply（bootstrap）となる。
+# ============================================================
+
+# --- tfstate bucket（tf project）: identity=ops × resource=tf は下流の ops が書く（INFRA-ADR-015） ---
+
+# plan / apply ともに全 tfstate bucket の read。
+# tfstateReader は devgist-tf が定義する custom role。predefined の read-only role には
+# storage.buckets.getIamPolicy が無く、plan が bucket IAM member を refresh できないため
+resource "google_storage_bucket_iam_member" "ci_tfstate_read" {
+  for_each = {
+    for pair in setproduct(
+      [local.ci_scope_terraform_plan_dev, local.ci_scope_terraform_apply_dev],
+      local.all_tfstate_bucket_ids,
+      ) : "${pair[0]}|${pair[1]}" => {
+      scope  = pair[0]
+      bucket = pair[1]
+    }
+  }
+
+  bucket = each.value.bucket
+  role   = "projects/${data.terraform_remote_state.tf.outputs.tf_project_id}/roles/tfstateReader"
+  member = "${local.github_ci_principal_set_prefix}/${each.value.scope}"
 }
 
-resource "github_actions_variable" "crawler_repo_url" {
-  repository    = local.github_repository_name
-  variable_name = "CRAWLER_REPO_URL"
-  value         = module.artifact_registries["crawler"].repository_url
+# apply は deploy 対象 root の state bucket に object の read/write（GCS backend の state と lock file）
+resource "google_storage_bucket_iam_member" "ci_apply_tfstate_write" {
+  for_each = local.ci_deploy_state_bucket_ids
+
+  bucket = each.value
+  role   = "roles/storage.objectUser"
+  member = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
 }
 
-resource "github_actions_variable" "crawler_image_name" {
-  repository    = local.github_repository_name
-  variable_name = "CRAWLER_IMAGE_NAME"
-  value         = module.artifact_registries["crawler"].repository_id
+# --- tf project: この root が書く project レベルの IAM member を plan が refresh するための read ---
+# tf project には write を付けない（tfstate 基盤は CI に載せない）
+resource "google_project_iam_member" "ci_plan_tf" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+  ])
+
+  project = data.terraform_remote_state.tf.outputs.tf_project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
+}
+
+resource "google_project_iam_member" "ci_apply_tf" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+  ])
+
+  project = data.terraform_remote_state.tf.outputs.tf_project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
+}
+
+# --- data-dev project: identity=ops × resource=data は ops が書く（INFRA-ADR-015） ---
+resource "google_project_iam_member" "ci_plan_data_dev" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+  ])
+
+  project = data.terraform_remote_state.data_dev.outputs.datalake_project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
+}
+
+resource "google_project_iam_member" "ci_apply_data_dev" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/storage.admin",                  # bucket の作成・更新・削除（data-dev の主リソース）
+    "roles/serviceusage.serviceUsageAdmin", # API 有効化
+  ])
+
+  project = data.terraform_remote_state.data_dev.outputs.datalake_project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
+}
+
+# --- datalake bucket（data-dev project） ---
+# plan が cursor / crawler の bucket IAM member を refresh するための read-only custom role。
+# datalakeIamReader は devgist-data/dev が定義する。apply は project の roles/storage.admin がカバーする
+resource "google_storage_bucket_iam_member" "ci_plan_datalake_iam_read" {
+  bucket = data.terraform_remote_state.data_dev.outputs.datalake_bucket_name
+  role   = "projects/${data.terraform_remote_state.data_dev.outputs.datalake_project_id}/roles/datalakeIamReader"
+  member = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
+}
+
+# --- ops project（同一 root） ---
+resource "google_project_iam_member" "ci_plan_ops" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/serviceusage.serviceUsageConsumer", # WIF direct access の quota project 利用
+  ])
+
+  project = data.google_project.project.project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
+}
+
+resource "google_project_iam_member" "ci_apply_ops" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/artifactregistry.admin",            # repository の作成・削除と repository IAM
+    "roles/iam.serviceAccountAdmin",           # SA の作成・削除と SA IAM
+    "roles/serviceusage.serviceUsageAdmin",    # API 有効化
+    "roles/serviceusage.serviceUsageConsumer", # WIF direct access の quota project 利用
+  ])
+
+  project = data.google_project.project.project_id
+  role    = each.value
+  member  = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_apply_dev}"
+}
+
+# plan が AR repository の IAM member を refresh するための read-only custom role。
+# predefined の read-only role には artifactregistry.repositories.getIamPolicy が無い。
+# 定義の変更は CI では通らない（apply principal に iam.roles.update を付けない）
+resource "google_project_iam_custom_role" "ar_repo_iam_reader" {
+  project     = data.google_project.project.project_id
+  role_id     = "arRepoIamReader"
+  title       = "Artifact Registry repository IAM reader"
+  description = "Read-only access to Artifact Registry repository IAM policies for terraform plan (INFRA-ADR-019)"
+  permissions = [
+    "artifactregistry.repositories.get",
+    "artifactregistry.repositories.getIamPolicy",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "ci_plan_crawler_repo_iam_read" {
+  project    = data.google_project.project.project_id
+  location   = module.artifact_registries["crawler"].location
+  repository = module.artifact_registries["crawler"].repository_id
+  role       = google_project_iam_custom_role.ar_repo_iam_reader.name
+  member     = "${local.github_ci_principal_set_prefix}/${local.ci_scope_terraform_plan_dev}"
 }
 
 # Cursor WIF → data-dev datalake。direct resource access（INFRA-ADR-014）。

--- a/infra/terraform/environments/devgist-ops/outputs.tf
+++ b/infra/terraform/environments/devgist-ops/outputs.tf
@@ -60,5 +60,10 @@ output "cursor_wif_audience" {
 
 output "github_wif_provider_name" {
   value       = module.github_wif.provider_name
-  description = "Full resource name of the GitHub Actions OIDC provider. ops Terraform also writes this to the GitHub repository variable GCP_GITHUB_WIF_PROVIDER."
+  description = "Full resource name of the GitHub Actions OIDC provider. The environments/github root writes this to the GitHub repository variable GCP_GITHUB_WIF_PROVIDER (INFRA-ADR-019)."
+}
+
+output "github_wif_pool_id" {
+  value       = module.github_wif.pool_id
+  description = "Workload identity pool ID for GitHub Actions OIDC. Used to build ci_scope principalSets in downstream roots (INFRA-ADR-019)."
 }

--- a/infra/terraform/environments/devgist-ops/providers.tf
+++ b/infra/terraform/environments/devgist-ops/providers.tf
@@ -8,10 +8,6 @@ provider "google-beta" {
   region  = var.gcp_default_region
 }
 
-provider "github" {
-  owner = local.github_repository_owner
-}
-
 terraform {
   required_version = "~>1.14.4"
   required_providers {
@@ -22,10 +18,6 @@ terraform {
     google-beta = {
       source  = "hashicorp/google-beta"
       version = "~>7.18.0"
-    }
-    github = {
-      source  = "integrations/github"
-      version = "~> 6.12.0"
     }
   }
 }

--- a/infra/terraform/environments/devgist-ops/terraform.tfvars
+++ b/infra/terraform/environments/devgist-ops/terraform.tfvars
@@ -1,0 +1,4 @@
+# 非 secret 値のみ。secret 値（cursor_oidc_subjects、service_account_user_emails）は
+# secrets.auto.tfvars（local、gitignore 済み）か TF_VAR_*（CI）で渡す（INFRA-ADR-019）
+gcp_project_id     = "haru256-devgist-ops"
+gcp_default_region = "us-central1"

--- a/infra/terraform/environments/devgist-ops/tests/ci_principals.tftest.hcl
+++ b/infra/terraform/environments/devgist-ops/tests/ci_principals.tftest.hcl
@@ -1,0 +1,156 @@
+mock_provider "google" {}
+mock_provider "google-beta" {}
+
+override_data {
+  target = data.google_project.project
+  values = {
+    project_id = "ops"
+    number     = "123456789"
+  }
+}
+
+override_data {
+  target = data.terraform_remote_state.data_dev
+  values = {
+    outputs = {
+      datalake_bucket_name = "mock-datalake-bucket"
+      datalake_project_id  = "mock-data-project"
+    }
+  }
+}
+
+override_data {
+  target = data.terraform_remote_state.tf
+  values = {
+    outputs = {
+      tf_project_id = "mock-tf-project"
+      tfstate_buckets = [
+        { project_id = "haru256-devgist-tf", bucket_id = "haru256-devgist-tf-tfstate" },
+        { project_id = "haru256-devgist-ops", bucket_id = "haru256-devgist-ops-tfstate" },
+        { project_id = "haru256-devgist-data-dev", bucket_id = "haru256-devgist-data-dev-tfstate" },
+        { project_id = "haru256-devgist-app-dev", bucket_id = "haru256-devgist-app-dev-tfstate" },
+        { project_id = "haru256-devgist-github", bucket_id = "haru256-devgist-github-tfstate" },
+      ]
+    }
+  }
+}
+
+variables {
+  gcp_project_id              = "ops"
+  gcp_default_region          = "us-central1"
+  cursor_oidc_subjects        = []
+  service_account_user_emails = []
+}
+
+run "ci_principals_get_tfstate_read_on_all_buckets" {
+  command = plan
+
+  assert {
+    condition     = length(google_storage_bucket_iam_member.ci_tfstate_read) == 10
+    error_message = "Expected tfstate read grants for plan/apply scopes on all five tfstate buckets"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.ci_tfstate_read["terraform-plan-dev|haru256-devgist-ops-tfstate"].role == "projects/mock-tf-project/roles/tfstateReader"
+    error_message = "Expected tfstate read to use the tfstateReader custom role defined in the tf project"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.ci_tfstate_read["terraform-apply-dev|haru256-devgist-ops-tfstate"].member == "principalSet://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/github-devgist/attribute.ci_scope/terraform-apply-dev"
+    error_message = "Expected tfstate read member to be the terraform-apply-dev ci_scope principalSet"
+  }
+}
+
+run "ci_apply_writes_only_deploy_state_buckets" {
+  command = plan
+
+  assert {
+    condition = toset(keys(google_storage_bucket_iam_member.ci_apply_tfstate_write)) == toset([
+      "haru256-devgist-ops-tfstate",
+      "haru256-devgist-data-dev-tfstate",
+      "haru256-devgist-app-dev-tfstate",
+    ])
+    error_message = "Expected apply write grants on the ops/data-dev/app-dev state buckets only (not tf, not github)"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.ci_apply_tfstate_write["haru256-devgist-ops-tfstate"].role == "roles/storage.objectUser"
+    error_message = "Expected apply state write to use storage.objectUser"
+  }
+}
+
+run "ci_principals_ops_project_roles" {
+  command = plan
+
+  assert {
+    condition = toset([for binding in values(google_project_iam_member.ci_plan_ops) : binding.role]) == toset([
+      "roles/viewer",
+      "roles/iam.securityReviewer",
+      "roles/serviceusage.serviceUsageConsumer",
+    ])
+    error_message = "Expected plan principal to be read-only on the ops project"
+  }
+
+  assert {
+    condition = toset([for binding in values(google_project_iam_member.ci_apply_ops) : binding.role]) == toset([
+      "roles/viewer",
+      "roles/iam.securityReviewer",
+      "roles/artifactregistry.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/serviceusage.serviceUsageConsumer",
+    ])
+    error_message = "Expected apply principal roles on the ops project"
+  }
+
+  assert {
+    condition     = !contains([for binding in values(google_project_iam_member.ci_apply_ops) : binding.role], "roles/resourcemanager.projectIamAdmin")
+    error_message = "Apply principal must not get project IAM admin (it would be able to change its own grants)"
+  }
+}
+
+run "ci_principals_data_dev_project_roles" {
+  command = plan
+
+  assert {
+    condition     = google_project_iam_member.ci_plan_data_dev["roles/viewer"].project == "mock-data-project"
+    error_message = "Expected plan principal viewer on the data-dev project from remote state"
+  }
+
+  assert {
+    condition = toset([for binding in values(google_project_iam_member.ci_apply_data_dev) : binding.role]) == toset([
+      "roles/viewer",
+      "roles/iam.securityReviewer",
+      "roles/storage.admin",
+      "roles/serviceusage.serviceUsageAdmin",
+    ])
+    error_message = "Expected apply principal roles on the data-dev project"
+  }
+}
+
+run "ci_plan_reads_datalake_and_ar_repo_iam_via_custom_roles" {
+  command = plan
+
+  assert {
+    condition     = google_storage_bucket_iam_member.ci_plan_datalake_iam_read.role == "projects/mock-data-project/roles/datalakeIamReader"
+    error_message = "Expected datalake IAM read to use the datalakeIamReader custom role defined in the data-dev root"
+  }
+
+  assert {
+    condition     = google_storage_bucket_iam_member.ci_plan_datalake_iam_read.bucket == "mock-datalake-bucket"
+    error_message = "Expected datalake IAM read on the data-dev datalake bucket"
+  }
+
+  assert {
+    condition = toset(google_project_iam_custom_role.ar_repo_iam_reader.permissions) == toset([
+      "artifactregistry.repositories.get",
+      "artifactregistry.repositories.getIamPolicy",
+    ])
+    error_message = "Expected arRepoIamReader to be read-only on repository IAM policies"
+  }
+
+  assert {
+    condition     = google_artifact_registry_repository_iam_member.ci_plan_crawler_repo_iam_read.member == "principalSet://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/github-devgist/attribute.ci_scope/terraform-plan-dev"
+    error_message = "Expected AR repo IAM read member to be the terraform-plan-dev ci_scope principalSet"
+  }
+}

--- a/infra/terraform/environments/devgist-ops/tests/cursor_oidc.tftest.hcl
+++ b/infra/terraform/environments/devgist-ops/tests/cursor_oidc.tftest.hcl
@@ -1,6 +1,5 @@
 mock_provider "google" {}
 mock_provider "google-beta" {}
-mock_provider "github" {}
 
 override_data {
   target = data.google_project.project
@@ -20,9 +19,27 @@ override_data {
   }
 }
 
+override_data {
+  target = data.terraform_remote_state.tf
+  values = {
+    outputs = {
+      tf_project_id = "mock-tf-project"
+      tfstate_buckets = [
+        { project_id = "haru256-devgist-tf", bucket_id = "haru256-devgist-tf-tfstate" },
+        { project_id = "haru256-devgist-ops", bucket_id = "haru256-devgist-ops-tfstate" },
+        { project_id = "haru256-devgist-data-dev", bucket_id = "haru256-devgist-data-dev-tfstate" },
+        { project_id = "haru256-devgist-app-dev", bucket_id = "haru256-devgist-app-dev-tfstate" },
+        { project_id = "haru256-devgist-github", bucket_id = "haru256-devgist-github-tfstate" },
+      ]
+    }
+  }
+}
+
 variables {
-  gcp_project_id     = "ops"
-  gcp_default_region = "us-central1"
+  gcp_project_id              = "ops"
+  gcp_default_region          = "us-central1"
+  cursor_oidc_subjects        = []
+  service_account_user_emails = []
 }
 
 run "grant_cursor_oidc_datalake_read_write" {
@@ -50,10 +67,6 @@ run "grant_cursor_oidc_datalake_read_write" {
 
 run "skip_cursor_oidc_datalake_when_allowlist_empty" {
   command = plan
-
-  variables {
-    cursor_oidc_subjects = []
-  }
 
   assert {
     condition     = length(google_storage_bucket_iam_member.cursor_oidc) == 0

--- a/infra/terraform/environments/devgist-ops/tests/github_wif.tftest.hcl
+++ b/infra/terraform/environments/devgist-ops/tests/github_wif.tftest.hcl
@@ -1,6 +1,5 @@
 mock_provider "google" {}
 mock_provider "google-beta" {}
-mock_provider "github" {}
 
 override_data {
   target = data.google_project.project
@@ -20,28 +19,31 @@ override_data {
   }
 }
 
-variables {
-  gcp_project_id     = "ops"
-  gcp_default_region = "us-central1"
+override_data {
+  target = data.terraform_remote_state.tf
+  values = {
+    outputs = {
+      tf_project_id = "mock-tf-project"
+      tfstate_buckets = [
+        { project_id = "haru256-devgist-tf", bucket_id = "haru256-devgist-tf-tfstate" },
+        { project_id = "haru256-devgist-ops", bucket_id = "haru256-devgist-ops-tfstate" },
+        { project_id = "haru256-devgist-data-dev", bucket_id = "haru256-devgist-data-dev-tfstate" },
+        { project_id = "haru256-devgist-app-dev", bucket_id = "haru256-devgist-app-dev-tfstate" },
+        { project_id = "haru256-devgist-github", bucket_id = "haru256-devgist-github-tfstate" },
+      ]
+    }
+  }
 }
 
-run "grant_github_oidc_crawler_writer" {
+variables {
+  gcp_project_id              = "ops"
+  gcp_default_region          = "us-central1"
+  cursor_oidc_subjects        = []
+  service_account_user_emails = []
+}
+
+run "github_wif_pool_and_provider_stay_single_entry" {
   command = plan
-
-  assert {
-    condition     = google_artifact_registry_repository_iam_member.github_oidc_dev.member == "principalSet://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/github-devgist/attribute.environment/dev"
-    error_message = "Expected GitHub OIDC writer member to be the environment principalSet"
-  }
-
-  assert {
-    condition     = google_artifact_registry_repository_iam_member.github_oidc_dev.role == "roles/artifactregistry.writer"
-    error_message = "Expected GitHub OIDC IAM role to be artifactregistry.writer"
-  }
-
-  assert {
-    condition     = google_artifact_registry_repository_iam_member.github_oidc_dev.repository == "crawler"
-    error_message = "Expected GitHub OIDC writer on the crawler Artifact Registry repository"
-  }
 
   assert {
     condition     = module.github_wif.pool_id == "github-devgist"
@@ -57,15 +59,70 @@ run "grant_github_oidc_crawler_writer" {
     condition     = module.github_wif.issuer_uri == "https://token.actions.githubusercontent.com"
     error_message = "Expected GitHub WIF issuer to be GitHub Actions OIDC"
   }
+}
+
+run "github_wif_condition_is_repository_ids_and_ci_scope" {
+  command = plan
 
   assert {
     condition = (
       strcontains(module.github_wif.attribute_condition, "assertion.repository_id == \"1106323394\"") &&
       strcontains(module.github_wif.attribute_condition, "assertion.repository_owner_id == \"31652298\"") &&
+      strcontains(module.github_wif.attribute_condition, "attribute.ci_scope != \"none\"") &&
       !strcontains(module.github_wif.attribute_condition, "environment") &&
       !strcontains(module.github_wif.attribute_condition, "workflow") &&
       !strcontains(module.github_wif.attribute_condition, "assertion.ref")
     )
-    error_message = "Expected GitHub WIF condition to be repository_id and repository_owner_id only"
+    error_message = "Expected GitHub WIF condition to be repository_id, repository_owner_id, and ci_scope != none only"
+  }
+}
+
+run "github_wif_mapping_synthesizes_ci_scope_without_environment_key" {
+  command = plan
+
+  assert {
+    condition     = !contains(keys(module.github_wif.attribute_mapping), "attribute.environment")
+    error_message = "Expected attribute.environment to be removed from the mapping (INFRA-ADR-019)"
+  }
+
+  assert {
+    condition = (
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "terraform-apply-dev") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "terraform-plan-dev") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "terraform-apply-prod") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "terraform-plan-prod") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "crawler-push-dev")
+    )
+    error_message = "Expected ci_scope mapping to contain all five scopes"
+  }
+
+  assert {
+    condition = (
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "/.github/workflows/terraform-apply.yml@refs/heads/main") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "/.github/workflows/terraform-plan.yml@refs/pull/") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "/.github/workflows/terraform-apply-prod.yml@refs/heads/main") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "/.github/workflows/crawler-deploy.yaml@refs/heads/main") &&
+      strcontains(module.github_wif.attribute_mapping["attribute.ci_scope"], "has(assertion.environment)")
+    )
+    error_message = "Expected ci_scope mapping to pin workflow files and guard the optional environment claim"
+  }
+}
+
+run "crawler_writer_is_bound_to_crawler_push_dev_scope" {
+  command = plan
+
+  assert {
+    condition     = google_artifact_registry_repository_iam_member.crawler_push_dev.member == "principalSet://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/github-devgist/attribute.ci_scope/crawler-push-dev"
+    error_message = "Expected crawler writer member to be the crawler-push-dev ci_scope principalSet"
+  }
+
+  assert {
+    condition     = google_artifact_registry_repository_iam_member.crawler_push_dev.role == "roles/artifactregistry.writer"
+    error_message = "Expected GitHub OIDC IAM role to be artifactregistry.writer"
+  }
+
+  assert {
+    condition     = google_artifact_registry_repository_iam_member.crawler_push_dev.repository == "crawler"
+    error_message = "Expected GitHub OIDC writer on the crawler Artifact Registry repository"
   }
 }

--- a/infra/terraform/environments/devgist-ops/variables.tf
+++ b/infra/terraform/environments/devgist-ops/variables.tf
@@ -10,8 +10,7 @@ variable "gcp_default_region" {
 
 variable "service_account_user_emails" {
   type        = set(string)
-  description = "Email addresses of users allowed to attach / actAs managed service accounts."
-  default     = []
+  description = "Email addresses of users allowed to attach / actAs managed service accounts. No default on purpose: set it in the gitignored secrets.auto.tfvars (local) or TF_VAR_service_account_user_emails (CI) so that an unset value fails instead of wiping grants (INFRA-ADR-019)."
 
   validation {
     condition = alltrue([
@@ -24,8 +23,7 @@ variable "service_account_user_emails" {
 
 variable "cursor_oidc_subjects" {
   type        = set(string)
-  description = "Cursor OIDC subject claims allowed to access the data-dev datalake via WIF direct resource access. Empty means no federated principal gets GCS IAM. Set this in the gitignored terraform.tfvars."
-  default     = []
+  description = "Cursor OIDC subject claims allowed to access the data-dev datalake via WIF direct resource access. Empty means no federated principal gets GCS IAM. No default on purpose: set it in the gitignored secrets.auto.tfvars (local) or TF_VAR_cursor_oidc_subjects (CI) so that an unset value fails instead of wiping grants (INFRA-ADR-019)."
 
   validation {
     condition = alltrue([

--- a/infra/terraform/environments/devgist-tf/.terraform.lock.hcl
+++ b/infra/terraform/environments/devgist-tf/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "~> 7.18.0"
   hashes = [
     "h1:Hqg6g5/5hFRK73xBE7ANAeuQbuw8ibuPrzXP7OOPxrk=",
+    "h1:p1/8oF64IGjiI47qa4OlsagwgtqGZUT5UU0Vtjv9g9M=",
     "zh:041dc216f7352e36af65d4a6d4a38d24fec4c05193a4f4c8cf69138e29dc9421",
     "zh:454c675e0487f011764eb0cd15d7b1e43d06a4e80ed056aeb4ad11df31368f81",
     "zh:4e76c8a1e5645f1e2c258c8074d4e9ecfc1d6383d207d03f492df16da389a120",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.18.0"
   constraints = "~> 7.18.0"
   hashes = [
+    "h1:qf+lQn4pQLcsIzX47cjYzTGA1X9TOaY+MQapdCX0OjQ=",
     "h1:uUkFpnD5xAlP+jXmG1Uva8qMpFfmoZEgHYk+oVFeW50=",
     "zh:3af9bb42f49a63c076b3a5e1e6fc21253c0b67390ca9e808c64876eb9c0e4293",
     "zh:4ffee6e1166750855b54853f7c186a6a8e2c07f37f390aae1b04434047a8d87a",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.13.1"
   hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
     "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
     "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
     "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",

--- a/infra/terraform/environments/devgist-tf/main.tf
+++ b/infra/terraform/environments/devgist-tf/main.tf
@@ -2,6 +2,7 @@ locals {
   # このTerraform構成で必要な全APIをリスト化
   required_services = [
     "storage.googleapis.com", # GCSモジュール用
+    "iam.googleapis.com",     # custom role 用
   ]
 }
 
@@ -27,4 +28,23 @@ module "tfstate_bucket" {
   bucket_gcp_project_id  = var.gcp_project_id
   tfstate_gcp_project_id = each.value
   depends_on             = [module.required_project_services]
+}
+
+# GitHub Actions CI の plan / apply が tfstate bucket を読み、bucket IAM member を refresh するための
+# read-only custom role（INFRA-ADR-019）。predefined の read-only role には
+# storage.buckets.getIamPolicy が無い。bucket への grant は ops が書く（INFRA-ADR-015）。
+# この role の定義変更はローカル apply（CI の apply principal には iam.roles.update を付けない）
+resource "google_project_iam_custom_role" "tfstate_reader" {
+  project     = data.google_project.project.project_id
+  role_id     = "tfstateReader"
+  title       = "Terraform state bucket reader"
+  description = "Read-only access to tfstate buckets and their IAM policies for terraform plan (INFRA-ADR-019)"
+  permissions = [
+    "storage.buckets.get",
+    "storage.buckets.getIamPolicy",
+    "storage.objects.get",
+    "storage.objects.list",
+  ]
+
+  depends_on = [module.required_project_services]
 }

--- a/infra/terraform/environments/devgist-tf/outputs.tf
+++ b/infra/terraform/environments/devgist-tf/outputs.tf
@@ -5,3 +5,8 @@ output "tfstate_buckets" {
   }]
   description = "List of all tfstate buckets with their project IDs"
 }
+
+output "tf_project_id" {
+  value       = data.google_project.project.project_id
+  description = "The GCP project ID that hosts the tfstate buckets. Downstream roots reference project-level custom roles via this ID (INFRA-ADR-019)"
+}

--- a/infra/terraform/environments/github/.terraform.lock.hcl
+++ b/infra/terraform/environments/github/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.12.0"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/infra/terraform/environments/github/Makefile
+++ b/infra/terraform/environments/github/Makefile
@@ -1,0 +1,2 @@
+include ../../../../make/help.mk
+include ../../../../make/terraform.mk

--- a/infra/terraform/environments/github/backend.tf
+++ b/infra/terraform/environments/github/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  # partial backend configurationで指定するため、ここでは空を設定
+  backend "gcs" {}
+}

--- a/infra/terraform/environments/github/config.gcs.tfbackend
+++ b/infra/terraform/environments/github/config.gcs.tfbackend
@@ -1,0 +1,1 @@
+bucket = "haru256-devgist-github-tfstate"

--- a/infra/terraform/environments/github/main.tf
+++ b/infra/terraform/environments/github/main.tf
@@ -1,0 +1,50 @@
+# GitHub リソース（Environment、repository variable）を管理する root（INFRA-ADR-019）。
+#
+# 変更頻度が低く、CI に載せるには GitHub App の PEM のような長寿命の秘密を
+# CI に置く必要があるため、plan / apply はローカルに限定する。
+# 認証は apply する人の GITHUB_TOKEN（INFRA-ADR-017 の手元運用）。
+# CI の workflow はこの root を対象にしない（.github/workflows/terraform-plan.yml /
+# terraform-apply.yml の deploy 対象外）。
+#
+# state bucket は haru256-devgist-github-tfstate。使う前に devgist-tf の
+# tfstate_gcp_project_ids に haru256-devgist-github を足して tf を apply すること。
+
+locals {
+  github_repository_owner = "haru-256"
+  github_repository_name  = "devgist"
+}
+
+# ops の Terraform state から GitHub Actions 連携に必要な値を参照する（INFRA-ADR-006）
+data "terraform_remote_state" "ops" {
+  backend = "gcs"
+
+  config = {
+    bucket = "haru256-devgist-ops-tfstate"
+  }
+}
+
+# GitHub Actions の Terraform 由来設定（INFRA-ADR-017）。
+# Environment は OIDC claim と IAM の契約ではなくなった（INFRA-ADR-019）が、
+# deployment 履歴と将来の protection の器として維持する
+resource "github_repository_environment" "dev" {
+  repository  = local.github_repository_name
+  environment = "dev"
+}
+
+resource "github_actions_variable" "gcp_github_wif_provider" {
+  repository    = local.github_repository_name
+  variable_name = "GCP_GITHUB_WIF_PROVIDER"
+  value         = data.terraform_remote_state.ops.outputs.github_wif_provider_name
+}
+
+resource "github_actions_variable" "crawler_repo_url" {
+  repository    = local.github_repository_name
+  variable_name = "CRAWLER_REPO_URL"
+  value         = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_url
+}
+
+resource "github_actions_variable" "crawler_image_name" {
+  repository    = local.github_repository_name
+  variable_name = "CRAWLER_IMAGE_NAME"
+  value         = data.terraform_remote_state.ops.outputs.crawler_artifact_registry_repository_id
+}

--- a/infra/terraform/environments/github/providers.tf
+++ b/infra/terraform/environments/github/providers.tf
@@ -1,0 +1,13 @@
+provider "github" {
+  owner = local.github_repository_owner
+}
+
+terraform {
+  required_version = "~>1.14.4"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.12.0"
+    }
+  }
+}

--- a/infra/terraform/environments/github/tests/github_actions.tftest.hcl
+++ b/infra/terraform/environments/github/tests/github_actions.tftest.hcl
@@ -1,36 +1,23 @@
-mock_provider "google" {}
-mock_provider "google-beta" {}
 mock_provider "github" {}
 
 override_data {
-  target = data.google_project.project
-  values = {
-    project_id = "ops"
-    number     = "123456789"
-  }
-}
-
-override_data {
-  target = data.terraform_remote_state.data_dev
+  target = data.terraform_remote_state.ops
   values = {
     outputs = {
-      datalake_bucket_name = "mock-datalake-bucket"
-      datalake_project_id  = "mock-data-project"
+      github_wif_provider_name                      = "projects/123456789/locations/global/workloadIdentityPools/github-devgist/providers/oidc"
+      crawler_artifact_registry_repository_url      = "us-central1-docker.pkg.dev/ops/crawler"
+      crawler_artifact_registry_repository_id       = "crawler"
+      crawler_artifact_registry_repository_location = "us-central1"
     }
   }
 }
 
-variables {
-  gcp_project_id     = "ops"
-  gcp_default_region = "us-central1"
-}
-
-run "write_github_actions_config_from_ops" {
+run "write_github_actions_config_from_github_root" {
   command = plan
 
   assert {
     condition     = github_repository_environment.dev.environment == "dev"
-    error_message = "Expected ops Terraform to manage GitHub Environment dev"
+    error_message = "Expected github root Terraform to manage GitHub Environment dev"
   }
 
   assert {
@@ -55,7 +42,12 @@ run "write_github_actions_config_from_ops" {
 
   assert {
     condition     = github_actions_variable.gcp_github_wif_provider.variable_name == "GCP_GITHUB_WIF_PROVIDER"
-    error_message = "Expected GCP_GITHUB_WIF_PROVIDER to be a repository variable written by ops"
+    error_message = "Expected GCP_GITHUB_WIF_PROVIDER to be a repository variable written by the github root"
+  }
+
+  assert {
+    condition     = github_actions_variable.gcp_github_wif_provider.value == "projects/123456789/locations/global/workloadIdentityPools/github-devgist/providers/oidc"
+    error_message = "Expected GCP_GITHUB_WIF_PROVIDER to come from the ops remote state"
   }
 
   assert {

--- a/infra/terraform/modules/workload_identity_oidc/outputs.tf
+++ b/infra/terraform/modules/workload_identity_oidc/outputs.tf
@@ -32,3 +32,8 @@ output "attribute_condition" {
   description = "CEL condition that tokens must satisfy."
   value       = google_iam_workload_identity_pool_provider.oidc.attribute_condition
 }
+
+output "attribute_mapping" {
+  description = "CEL expressions that map IdP claims to Google STS attributes."
+  value       = google_iam_workload_identity_pool_provider.oidc.attribute_mapping
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GitHub Actions から terraform plan / apply を実行する CI/CD を構築する。認証は既存の WIF pool `github-devgist` を維持し、custom attribute `ci_scope`（operation × environment）ごとの principalSet で認可する。設計の正本は INFRA-ADR-019（本 PR で追加）。

## Why

- INFRA-ADR-011 が「plan / apply は別 ADR で設計する」と後続に送っていた件の実装
- 既存の `attribute.environment/dev` 主キーでは、同じ Environment を使う全 workflow が write 権限を共有しうる（PR の YAML が Environment 名を選べる問題）
- GitHub リソース（Environment / repository variable）は `GITHUB_TOKEN` では CI から write できず、GitHub App を置くと長寿命の PEM が PR の YAML から参照可能になる。変更頻度の低さと自動化メリットを天秤にかけ、`environments/github` root に分離してローカル apply に限定する（GitHub App は導入しない）

## 関連 Issue

- #60（digest 更新 PR の自動作成 CI は本 PR のスコープ外・後続）

## 変更内容

- `docs(adr)`: INFRA-ADR-019 を追加（011/016 への参照と README 類の索引を更新）
- `feat(ci)`: `find_terraform_roots.py` に `--deploy-exclude` を追加し、`deploy_roots` を出力（pytest 3 件追加）
- `feat(terraform)`:
  - `github_wif` の mapping に `attribute.ci_scope` を CEL 合成（workflow_ref + event_name + ref + environment）。condition は `repository_id` + `repository_owner_id` + `ci_scope != "none"`。`attribute.environment` は廃止
  - crawler AR writer を `attribute.ci_scope/crawler-push-dev` に付け替え（`moved` block でリネーム）
  - plan / apply principal の guest IAM を INFRA-ADR-015 の表どおり ops / app-dev に追加。`getIamPolicy` を read-only で取る predefined role が無いため custom role を 3 つ定義（`tfstateReader`=tf、`datalakeIamReader`=data-dev、`arRepoIamReader`=ops）
  - GitHub リソースを `environments/github` root に分離（ops から `state rm` + `import` で移行）
  - `cursor_oidc_subjects` / `service_account_user_emails` の `default = []` を削除し、未設定を fail に変更
  - 非 secret の `terraform.tfvars` を version 管理（gitignore に例外）。secret は `secrets.auto.tfvars`（local）/ `TF_VAR_*`（CI）
- `feat(ci)`: `terraform-plan.yml`（same-repo PR で read-only speculative plan → PR コメント）と `terraform-apply.yml`（push main / dispatch で plan → artifact → saved plan apply を data-dev → ops → app-dev の直列で）を追加。composite action `terraform-gcp-plan` / `terraform-gcp-apply` を新設。crawler-deploy の push trigger を `main` に限定

## 影響範囲

- **IAM**: `ci_scope` principalSet への grant を多数追加。`attribute.environment/dev` への AR writer は `attribute.ci_scope/crawler-push-dev` に付け替わる
- **行動変**: crawler-deploy が feature branch push で走らなくなる（016 からの変更。main のみ）
- **運用**: merge 後は data-dev → ops → app-dev が CI で自動 apply される。`devgist-tf` と `environments/github` はローカル apply のまま
- **移行**: 下記 bootstrap 手順（ローカル apply と state 移行）が必要

## 確認方法

この VM で CI 相当をすべて実行済み（GCP 認証が必要な plan/apply 自体は bootstrap 後の CI で確認）。

- `terraform fmt -check -recursive infra/terraform` — OK
- 全 environment root（tf / ops / data-dev / app-dev / github）で `init -backend=false` + `validate` — OK
- `terraform test`: ops 11/11、github 1/1、app-dev 7/7、workload_identity_oidc module 2/2 — OK
- `tflint`（全 root、repo の .tflint.hcl）— 指摘なし
- `trivy config --severity=HIGH,CRITICAL infra/terraform` — 指摘なし
- `pytest .github/scripts/tests` — 8/8 OK
- workflow / action YAML のパース — OK
- root 検出: `deploy_roots` が `devgist-app/dev`, `devgist-data/dev`, `devgist-ops` の 3 件（tf / github を除外）になることを確認

## レビュー観点

- **`ci_scope` の CEL mapping**（`devgist-ops/main.tf`）: apply 系は `environment` も条件に含め、prod の承認ゲートと identity を結合する設計。CEL は apply 時にしか検証できないため、bootstrap apply での確認をお願いします
- **prod は別 workflow ファイルにする変更**: Q-G で「`terraform-apply.yml` への dispatch 追加」としていましたが、dispatch の input は JWT claim に載らず、同一ファイルでは prod 用 plan job（environment 無し）と dev 用 plan job を `ci_scope` で区別できないため、prod は `terraform-apply-prod.yml` を環境作成時に足す形に変えています（mapping には prod 条件を済ませてあります）
- **`crawler_image` の digest**: 最新の crawler-deploy 成功 run のログから取得した値（`sha256:bdb4626f...`）を committed tfvars に入れています。ローカルの state と一致するか、merge 前に PR の plan コメントで diff が出ないことを確認してください
- **bootstrap 手順**（下記）の順序と state 移行コマンド

## 補足: bootstrap 手順（merge 前後にローカルで実行）

merge 前にこのブランチを pull すると、ローカルの未追跡 `terraform.tfvars` が追跡済みファイルと衝突します。先に `mv terraform.tfvars secrets.auto.tfvars` して secret 値（`cursor_oidc_subjects` など）だけを残し、非 secret 値は commit 済みの `terraform.tfvars` に寄せてください。

1. `devgist-tf`: `tfstate_gcp_project_ids` に `haru256-devgist-github` を追加 → plan 内容を確認 → apply（`tfstateReader` custom role と github 用 state bucket が作られる）
2. `devgist-data/dev`: plan 確認 → apply（`datalakeIamReader` custom role）
3. `devgist-ops`: GitHub リソースを state から外す → plan 確認 → apply（WIF mapping 切替 + CI principal IAM）
   ```bash
   terraform state rm github_repository_environment.dev \
     github_actions_variable.gcp_github_wif_provider \
     github_actions_variable.crawler_repo_url \
     github_actions_variable.crawler_image_name
   ```
4. `devgist-app/dev`: plan 確認 → apply（CI principal IAM）
5. `environments/github`: `make init` 後に import（plan で差分が出ないことを確認。apply は不要なはず）
   ```bash
   terraform import github_repository_environment.dev devgist:dev
   terraform import github_actions_variable.gcp_github_wif_provider devgist:GCP_GITHUB_WIF_PROVIDER
   terraform import github_actions_variable.crawler_repo_url devgist:CRAWLER_REPO_URL
   terraform import github_actions_variable.crawler_image_name devgist:CRAWLER_IMAGE_NAME
   ```
6. GitHub 側: repository secret `CURSOR_OIDC_SUBJECTS` / `SERVICE_ACCOUNT_USER_EMAILS` を HCL list 形式（例: `["user:308716925"]`）で作成。作成済みの GitHub App と `TF_GITHUB_APP_*` の secret / variable を削除
7. merge 後: 初回の Terraform Apply が全 root で no-op（または意図した差分のみ）で通ることを確認。権限不足（403）が出たらエラーメッセージの権限をロールに足して手元 apply し、再実行

なお Ruleset の required checks に新 workflow `Terraform Plan` を含めるかどうかはお任せします（含めると infra PR で plan 成功が必須になります）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-992349bf-91bc-42bc-a753-4bb3ed49f90f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-992349bf-91bc-42bc-a753-4bb3ed49f90f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

